### PR TITLE
feat: Enhance Clickhouse and Slippy configurations with default values and improved error messages

### DIFF
--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -134,6 +134,10 @@ func ClickhouseLoadConfig() (*ClickhouseConfig, error) {
 		return nil, fmt.Errorf("failed to bind environment variable for chport: %w", err)
 	}
 
+	// Set defaults for optional fields
+	viper.SetDefault("chport", "9440")
+	viper.SetDefault("chskipverify", "false")
+
 	// Read environment variables
 	viper.AutomaticEnv()
 
@@ -166,11 +170,13 @@ func ClickhouseValidateConfig(clickhouseConfig *ClickhouseConfig) error {
 	if clickhouseConfig.ChDatabase == "" {
 		return fmt.Errorf("clickhouse database is required")
 	}
+	// Port and SkipVerify have defaults, so they should always be set
+	// But validate they have reasonable values if present
 	if clickhouseConfig.ChPort == "" {
-		return fmt.Errorf("clickhouse port is required")
+		return fmt.Errorf("clickhouse port is required (should default to 9440)")
 	}
 	if clickhouseConfig.ChSkipVerify == "" {
-		return fmt.Errorf("clickhouse skip verify is required")
+		return fmt.Errorf("clickhouse skip verify is required (should default to false)")
 	}
 	if clickhouseConfig.ChSkipVerify != "true" && clickhouseConfig.ChSkipVerify != "false" {
 		return fmt.Errorf("clickhouse skip verify must be true or false")

--- a/slippy/README.md
+++ b/slippy/README.md
@@ -51,22 +51,22 @@ Slippy implements the **Routing Slip** pattern for distributed pipeline orchestr
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                          CI/CD Job Execution                              │
+│                          CI/CD Job Execution                             │
 ├──────────────────────────────────────────────────────────────────────────┤
-│                                                                           │
+│                                                                          │
 │   ┌──────────────┐       ┌──────────────────┐       ┌──────────────┐     │
 │   │   PRE-JOB    │       │   ACTUAL JOB     │       │   POST-JOB   │     │
 │   │   (Slippy)   │──────▶│   (Your Code)    │──────▶│   (Slippy)   │     │
 │   └──────────────┘       └──────────────────┘       └──────────────┘     │
-│          │                        │                        │              │
-│          │   correlation_id       │   correlation_id       │              │
-│          └───────────────────────▶│───────────────────────▶│              │
-│                                                                           │
+│          │                        │                        │             │
+│          │   correlation_id       │   correlation_id       │             │
+│          └───────────────────────▶│───────────────────────▶│             │
+│                                                                          │
 │   • Resolve slip          • Build/Test/Deploy      • Update status       │
 │   • Check prereqs         • Any pipeline work      • Record outcome      │
 │   • Hold if needed        • Has correlation_id     • Has correlation_id  │
-│   • Output correlation_id                                                 │
-│                                                                           │
+│   • Output correlation_id                                                │
+│                                                                          │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/slippy/config.go
+++ b/slippy/config.go
@@ -123,19 +123,27 @@ func ConfigFromEnv() Config {
 // Returns an error describing any missing or invalid settings.
 func (c Config) Validate() error {
 	if c.ClickHouseConfig == nil {
-		return fmt.Errorf("%w: ClickHouseConfig is required", ErrInvalidConfiguration)
+		// Try to load again to get the actual error
+		if _, err := ch.ClickhouseLoadConfig(); err != nil {
+			return fmt.Errorf("%w: ClickHouse configuration failed to load: %w (check CLICKHOUSE_HOSTNAME, CLICKHOUSE_PORT, CLICKHOUSE_USERNAME, CLICKHOUSE_PASSWORD, CLICKHOUSE_DATABASE env vars)", ErrInvalidConfiguration, err)
+		}
+		return fmt.Errorf("%w: ClickHouseConfig is required (check CLICKHOUSE_* environment variables)", ErrInvalidConfiguration)
 	}
 	if err := ch.ClickhouseValidateConfig(c.ClickHouseConfig); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidConfiguration, err)
 	}
 	if c.PipelineConfig == nil {
+		// Try to load again to get the actual error
+		if _, err := LoadPipelineConfig(); err != nil {
+			return fmt.Errorf("%w: Pipeline configuration failed to load: %w (check SLIPPY_PIPELINE_CONFIG env var)", ErrInvalidConfiguration, err)
+		}
 		return fmt.Errorf("%w: PipelineConfig is required (set SLIPPY_PIPELINE_CONFIG)", ErrInvalidConfiguration)
 	}
 	if c.GitHubAppID == 0 {
-		return fmt.Errorf("%w: GitHubAppID is required", ErrInvalidConfiguration)
+		return fmt.Errorf("%w: GitHubAppID is required (set SLIPPY_GITHUB_APP_ID)", ErrInvalidConfiguration)
 	}
 	if c.GitHubPrivateKey == "" {
-		return fmt.Errorf("%w: GitHubPrivateKey is required", ErrInvalidConfiguration)
+		return fmt.Errorf("%w: GitHubPrivateKey is required (set SLIPPY_GITHUB_APP_PRIVATE_KEY)", ErrInvalidConfiguration)
 	}
 	if c.HoldTimeout <= 0 {
 		return fmt.Errorf("%w: HoldTimeout must be positive", ErrInvalidConfiguration)

--- a/slippy/config.go
+++ b/slippy/config.go
@@ -50,6 +50,10 @@ type Config struct {
 
 	// Database is the ClickHouse database name (default: "ci")
 	Database string
+
+	// Internal fields for error tracking
+	clickhouseLoadErr error // Error from ClickHouse config loading
+	pipelineLoadErr   error // Error from pipeline config loading
 }
 
 // DefaultConfig returns a Config with sensible default values.
@@ -79,13 +83,19 @@ func ConfigFromEnv() Config {
 	cfg := DefaultConfig()
 
 	// ClickHouse - use the standard clickhouse config loader
-	if chConfig, err := ch.ClickhouseLoadConfig(); err == nil {
+	chConfig, err := ch.ClickhouseLoadConfig()
+	if err == nil {
 		cfg.ClickHouseConfig = chConfig
+	} else {
+		cfg.clickhouseLoadErr = err
 	}
 
 	// Pipeline configuration
-	if pipelineConfig, err := LoadPipelineConfig(); err == nil {
+	pipelineConfig, err := LoadPipelineConfig()
+	if err == nil {
 		cfg.PipelineConfig = pipelineConfig
+	} else {
+		cfg.pipelineLoadErr = err
 	}
 
 	// GitHub App authentication
@@ -123,27 +133,45 @@ func ConfigFromEnv() Config {
 // Returns an error describing any missing or invalid settings.
 func (c Config) Validate() error {
 	if c.ClickHouseConfig == nil {
-		// Try to load again to get the actual error
-		if _, err := ch.ClickhouseLoadConfig(); err != nil {
-			return fmt.Errorf("%w: ClickHouse configuration failed to load: %w (check CLICKHOUSE_HOSTNAME, CLICKHOUSE_PORT, CLICKHOUSE_USERNAME, CLICKHOUSE_PASSWORD, CLICKHOUSE_DATABASE env vars)", ErrInvalidConfiguration, err)
+		if c.clickhouseLoadErr != nil {
+			return fmt.Errorf(
+				"%w: ClickHouse configuration failed to load: %w (check CLICKHOUSE_HOSTNAME, CLICKHOUSE_PORT, CLICKHOUSE_USERNAME, CLICKHOUSE_PASSWORD, CLICKHOUSE_DATABASE env vars)",
+				ErrInvalidConfiguration,
+				c.clickhouseLoadErr,
+			)
 		}
-		return fmt.Errorf("%w: ClickHouseConfig is required (check CLICKHOUSE_* environment variables)", ErrInvalidConfiguration)
+		return fmt.Errorf(
+			"%w: ClickHouseConfig is required (check CLICKHOUSE_* environment variables)",
+			ErrInvalidConfiguration,
+		)
 	}
 	if err := ch.ClickhouseValidateConfig(c.ClickHouseConfig); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidConfiguration, err)
 	}
 	if c.PipelineConfig == nil {
-		// Try to load again to get the actual error
-		if _, err := LoadPipelineConfig(); err != nil {
-			return fmt.Errorf("%w: Pipeline configuration failed to load: %w (check SLIPPY_PIPELINE_CONFIG env var)", ErrInvalidConfiguration, err)
+		if c.pipelineLoadErr != nil {
+			return fmt.Errorf(
+				"%w: Pipeline configuration failed to load: %w (check SLIPPY_PIPELINE_CONFIG env var)",
+				ErrInvalidConfiguration,
+				c.pipelineLoadErr,
+			)
 		}
-		return fmt.Errorf("%w: PipelineConfig is required (set SLIPPY_PIPELINE_CONFIG)", ErrInvalidConfiguration)
+		return fmt.Errorf(
+			"%w: PipelineConfig is required (set SLIPPY_PIPELINE_CONFIG)",
+			ErrInvalidConfiguration,
+		)
 	}
 	if c.GitHubAppID == 0 {
-		return fmt.Errorf("%w: GitHubAppID is required (set SLIPPY_GITHUB_APP_ID)", ErrInvalidConfiguration)
+		return fmt.Errorf(
+			"%w: GitHubAppID is required (set SLIPPY_GITHUB_APP_ID)",
+			ErrInvalidConfiguration,
+		)
 	}
 	if c.GitHubPrivateKey == "" {
-		return fmt.Errorf("%w: GitHubPrivateKey is required (set SLIPPY_GITHUB_APP_PRIVATE_KEY)", ErrInvalidConfiguration)
+		return fmt.Errorf(
+			"%w: GitHubPrivateKey is required (set SLIPPY_GITHUB_APP_PRIVATE_KEY)",
+			ErrInvalidConfiguration,
+		)
 	}
 	if c.HoldTimeout <= 0 {
 		return fmt.Errorf("%w: HoldTimeout must be positive", ErrInvalidConfiguration)

--- a/slippy/default.json
+++ b/slippy/default.json
@@ -4,30 +4,29 @@
   "description": "MyCarrier CI/CD pipeline configuration for routing slip orchestration",
   "steps": [
     {
-      "name": "push_parsed",
-      "description": "Initial push event processing - parses webhook and creates routing slip",
-      "prerequisites": []
-    },
-    {
       "name": "builds_completed",
       "description": "All component container builds finished successfully",
-      "prerequisites": ["push_parsed"],
+      "prerequisites": [],
       "aggregates": "build"
     },
     {
       "name": "unit_tests_completed",
       "description": "All component unit tests finished successfully",
-      "prerequisites": ["push_parsed"],
-      "aggregates": "unit_test"
+      "prerequisites": []
     },
     {
-      "name": "secret_scan_completed",
+      "name": "secret_scan",
       "description": "Security secret scanning finished - checks for leaked credentials",
-      "prerequisites": ["push_parsed"]
+      "prerequisites": []
+    },
+    {
+      "name": "package_artifact",
+      "description": "Published internal nuget/npm packages",
+      "prerequisites": []
     },
     {
       "name": "dev_deploy",
-      "description": "Deployment to development environment via GitOps",
+      "description": "Deployment to development/feature environment",
       "prerequisites": ["builds_completed", "unit_tests_completed", "secret_scan_completed"]
     },
     {
@@ -37,8 +36,8 @@
     },
     {
       "name": "preprod_deploy",
-      "description": "Deployment to pre-production environment via GitOps",
-      "prerequisites": ["dev_tests"]
+      "description": "Deployment to pre-production environment",
+      "prerequisites": ["builds_completed", "unit_tests_completed", "secret_scan_completed"]
     },
     {
       "name": "preprod_tests",
@@ -46,30 +45,25 @@
       "prerequisites": ["preprod_deploy"]
     },
     {
+      "name": "prod_gate",
+      "description": "Checks that the code is ready to be promoted to production",
+      "is_gate": true,
+      "prerequisites": ["preprod_deploy","preprod_tests"]
+    },
+    {
       "name": "prod_release_created",
       "description": "GitHub release created for production deployment",
-      "prerequisites": ["preprod_tests"]
+      "prerequisites": ["prod_gate"]
     },
     {
       "name": "prod_deploy",
-      "description": "Deployment to production environment via GitOps",
-      "prerequisites": ["prod_release_created"]
+      "description": "Deployment to production environment",
+      "prerequisites": ["prod_gate", "prod_release_created"]
     },
     {
       "name": "prod_tests",
       "description": "Smoke tests in production environment",
-      "prerequisites": ["prod_deploy"]
-    },
-    {
-      "name": "alert_gate",
-      "description": "Alert monitoring gate - verifies no anomalies in monitoring systems",
-      "prerequisites": ["prod_tests"],
-      "is_gate": true
-    },
-    {
-      "name": "prod_steady_state",
-      "description": "Production confirmed stable - pipeline complete",
-      "prerequisites": ["alert_gate"]
+      "prerequisites": ["prod_gate", "prod_deploy"]
     }
   ]
 }


### PR DESCRIPTION
This pull request improves configuration handling and validation for ClickHouse and the pipeline, and refines the pipeline step definitions in `default.json` for clarity and correctness. The most important changes are grouped below.

**Configuration improvements:**

* Added default values for `chport` (set to `"9440"`) and `chskipverify` (set to `"false"`) in `ClickhouseLoadConfig`, ensuring these optional fields are always set unless overridden.
* Enhanced validation error messages in `Config.Validate()` to provide more actionable feedback, including environment variable hints when configuration loading fails for ClickHouse, PipelineConfig, GitHubAppID, and GitHubPrivateKey.
* Updated `ClickhouseValidateConfig` to clarify that `chport` and `chskipverify` should have default values and improved their error messages to reflect these defaults.

**Pipeline configuration updates (`default.json`):**

* Refactored pipeline steps by removing the initial `push_parsed` step and updating prerequisites for subsequent steps to reflect the new flow. Added new steps such as `package_artifact` and renamed `secret_scan_completed` to `secret_scan`.
* Simplified deployment and gate steps: replaced the `alert_gate` and `prod_steady_state` steps with a new `prod_gate` step, adjusted prerequisites for deployment and release steps, and clarified descriptions for each environment.