### PR TITLE
chore(deps): update goLibMyCarrier to v1.3.63

### DIFF
--- a/clickhousemigrator/go.mod
+++ b/clickhousemigrator/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.42.0
-	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.57
+	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.63
 )
 
 replace github.com/MyCarrier-DevOps/goLibMyCarrier/logger => ../logger

--- a/github/go.mod
+++ b/github/go.mod
@@ -3,7 +3,7 @@ module github.com/MyCarrier-DevOps/goLibMyCarrier/github
 go 1.26
 
 require (
-	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.57
+	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.63
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,3 @@ go 1.26
 //   github.com/MyCarrier-DevOps/goLibMyCarrier/slippy
 //   github.com/MyCarrier-DevOps/goLibMyCarrier/logger
 // etc.
-
-require github.com/google/go-github/v82 v82.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/go-github/v82 v82.0.0 h1:OH09ESON2QwKCUVMYmMcVu1IFKFoaZHwqYaUtr/MVfk=
-github.com/google/go-github/v82 v82.0.0/go.mod h1:hQ6Xo0VKfL8RZ7z1hSfB4fvISg0QqHOqe9BP0qo+WvM=

--- a/slippy/go.mod
+++ b/slippy/go.mod
@@ -4,9 +4,9 @@ go 1.26
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.42.0
-	github.com/MyCarrier-DevOps/goLibMyCarrier/clickhouse v1.3.57
-	github.com/MyCarrier-DevOps/goLibMyCarrier/github v1.3.57
-	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.57
+	github.com/MyCarrier-DevOps/goLibMyCarrier/clickhouse v1.3.63
+	github.com/MyCarrier-DevOps/goLibMyCarrier/github v1.3.63
+	github.com/MyCarrier-DevOps/goLibMyCarrier/logger v1.3.63
 	github.com/testcontainers/testcontainers-go v0.40.0
 )
 
@@ -100,7 +100,7 @@ require (
 
 require (
 	github.com/ClickHouse/ch-go v0.70.0 // indirect
-	github.com/MyCarrier-DevOps/goLibMyCarrier/clickhousemigrator v1.3.57
+	github.com/MyCarrier-DevOps/goLibMyCarrier/clickhousemigrator v1.3.63
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect


### PR DESCRIPTION
## Dependency Update

| Field | Value |
|-------|-------|
| Library | `github.com/MyCarrier-DevOps/goLibMyCarrier` |
| Previous version | `../clickhouse` |
| New version | `v1.3.63` |
| Repository | `MyCarrier-DevOps/goLibMyCarrier` |

### Changes

See [releases](https://github.com/MyCarrier-DevOps/goLibMyCarrier/releases) for changelog.

### Checklist

- [ ] `go.mod` updated
- [ ] `go.sum` regenerated via `go mod tidy`
- [ ] Tests pass

---
_Created by go-lib-renovate.sh (local mirror of Copilot Go-Lib Renovate agent)_