### PR TITLE
feat: Implement Ping method to verify ClickHouse connection health and prevent stale connections

### DIFF
--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/spf13/viper"
@@ -92,6 +93,7 @@ func retryOperation(ctx context.Context, operation func() error) error {
 // ClickhouseSessionInterface defines the interface for ClickHouse session operations
 type ClickhouseSessionInterface interface {
 	Connect(ch *ClickhouseConfig, ctx context.Context) error
+	Ping(ctx context.Context) error
 	Query(ctx context.Context, query string) (Rows, error)
 	QueryWithArgs(ctx context.Context, query string, args ...interface{}) (Rows, error)
 	QueryRow(ctx context.Context, query string, args ...interface{}) Row
@@ -282,6 +284,21 @@ func (chsession *ClickhouseSession) Connect(ch *ClickhouseConfig, ctx context.Co
 			TLS: &tls.Config{
 				InsecureSkipVerify: chsession.skipVerify,
 			},
+
+			// Pool health settings to prevent stale connections from silently
+			// blocking operations until Linux TCP retransmission timeout (~7 min).
+			// ConnMaxLifetime reaps connections before LB/firewall idle timeouts
+			// kill them. DialContext enables TCP keepalives so the OS detects
+			// dead peers proactively via keepalive probes.
+			DialContext: func(ctx context.Context, addr string) (net.Conn, error) {
+				return (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext(ctx, "tcp", addr)
+			},
+			ConnMaxLifetime: 5 * time.Minute,
+			MaxOpenConns:    10,
+			MaxIdleConns:    5,
 		})
 		if err != nil {
 			return fmt.Errorf("error connecting to ClickHouse: %w", err)
@@ -361,6 +378,14 @@ func (ch *ClickhouseSession) ExecWithArgs(ctx context.Context, stmt string, args
 	})
 }
 
+// Ping verifies the connection to ClickHouse is alive.
+func (ch *ClickhouseSession) Ping(ctx context.Context) error {
+	if ch.conn == nil {
+		return fmt.Errorf("clickhouse connection is not established")
+	}
+	return ch.conn.Ping(ctx)
+}
+
 // Close ClickHouse connection
 func (ch *ClickhouseSession) Close() error {
 	if ch.conn != nil {
@@ -391,6 +416,10 @@ func NewSessionFromConn(conn Conn) ClickhouseSessionInterface {
 
 func (w *connWrapper) Connect(cfg *ClickhouseConfig, ctx context.Context) error {
 	return nil // Already connected
+}
+
+func (w *connWrapper) Ping(ctx context.Context) error {
+	return w.conn.Ping(ctx)
 }
 
 func (w *connWrapper) Query(ctx context.Context, query string) (Rows, error) {

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -186,6 +186,11 @@ func (m *MockClickhouseSession) Close() error {
 	return args.Error(0)
 }
 
+func (m *MockClickhouseSession) Ping(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 func (m *MockClickhouseSession) Conn() driver.Conn {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -2039,3 +2039,59 @@ func TestIsTransientError(t *testing.T) {
 		})
 	}
 }
+
+func TestClickhouseSession_Ping_NilConnection(t *testing.T) {
+	session := &ClickhouseSession{
+		conn: nil,
+	}
+
+	err := session.Ping(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "clickhouse connection is not established")
+}
+
+func TestClickhouseSession_Ping_Success(t *testing.T) {
+	mockConn := &MockConn{}
+	ctx := context.Background()
+	mockConn.On("Ping", ctx).Return(nil)
+
+	session := &ClickhouseSession{
+		conn: mockConn,
+	}
+
+	err := session.Ping(ctx)
+
+	assert.NoError(t, err)
+	mockConn.AssertExpectations(t)
+}
+
+func TestClickhouseSession_Ping_Error(t *testing.T) {
+	mockConn := &MockConn{}
+	ctx := context.Background()
+	expectedErr := errors.New("connection dead")
+	mockConn.On("Ping", ctx).Return(expectedErr)
+
+	session := &ClickhouseSession{
+		conn: mockConn,
+	}
+
+	err := session.Ping(ctx)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	mockConn.AssertExpectations(t)
+}
+
+func TestConnWrapper_Ping(t *testing.T) {
+	mockConn := &MockConn{}
+	ctx := context.Background()
+	mockConn.On("Ping", ctx).Return(nil)
+
+	wrapper := NewSessionFromConn(mockConn)
+
+	err := wrapper.Ping(ctx)
+
+	assert.NoError(t, err)
+	mockConn.AssertExpectations(t)
+}

--- a/clickhouse/clickhousetest/mock_session.go
+++ b/clickhouse/clickhousetest/mock_session.go
@@ -46,6 +46,11 @@ type MockSession struct {
 	ConnectCalls []ConnectCall
 	ConnectErr   error
 
+	// Ping behavior
+	PingFunc  func(ctx context.Context) error
+	PingCalls int
+	PingErr   error
+
 	// Query behavior
 	QueryFunc  func(ctx context.Context, query string) (driver.Rows, error)
 	QueryCalls []QueryCall
@@ -91,6 +96,15 @@ func (m *MockSession) Connect(cfg *ch.ClickhouseConfig, ctx context.Context) err
 		return m.ConnectFunc(ctx)
 	}
 	return m.ConnectErr
+}
+
+// Ping implements ClickhouseSessionInterface.Ping
+func (m *MockSession) Ping(ctx context.Context) error {
+	m.PingCalls++
+	if m.PingFunc != nil {
+		return m.PingFunc(ctx)
+	}
+	return m.PingErr
 }
 
 // Query implements ClickhouseSessionInterface.Query
@@ -159,6 +173,7 @@ func (m *MockSession) Conn() driver.Conn {
 // Reset clears all recorded calls for reuse
 func (m *MockSession) Reset() {
 	m.ConnectCalls = nil
+	m.PingCalls = 0
 	m.QueryCalls = nil
 	m.QueryWithArgsCalls = nil
 	m.QueryRowCalls = nil

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -2010,7 +2010,7 @@ func TestOtelLogger_DefaultPortConstants(t *testing.T) {
 // correlation fields (TraceID, SpanID) that the SDK log bridge extracts from ctx.
 type captureOtelLogger struct {
 	embedded.Logger // required by the otellog.Logger interface
-	calls []captureEmitCall
+	calls           []captureEmitCall
 }
 
 type captureEmitCall struct {

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -642,6 +642,11 @@ func (s *ClickHouseStore) Close() error {
 	return s.session.Close()
 }
 
+// Ping verifies the ClickHouse connection is alive.
+func (s *ClickHouseStore) Ping(ctx context.Context) error {
+	return s.session.Ping(ctx)
+}
+
 // InsertAncestryLink writes a single direct-parent link to the slip_ancestry table.
 // Each slip has at most one parent entry, keeping storage O(1) per slip.
 func (s *ClickHouseStore) InsertAncestryLink(ctx context.Context, slip *Slip, parent AncestryEntry) error {

--- a/slippy/clickhouse_store_integration_test.go
+++ b/slippy/clickhouse_store_integration_test.go
@@ -192,6 +192,10 @@ func (s *testClickhouseSession) Connect(ch *ch.ClickhouseConfig, ctx context.Con
 	return nil // Already connected
 }
 
+func (s *testClickhouseSession) Ping(ctx context.Context) error {
+	return s.conn.Ping(ctx)
+}
+
 func (s *testClickhouseSession) Query(ctx context.Context, query string) (ch.Rows, error) {
 	return s.conn.Query(ctx, query)
 }

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -2040,3 +2040,33 @@ func TestClickHouseStore_FindByCommits_QueryError(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
+
+func TestClickHouseStore_Ping_Success(t *testing.T) {
+	mockSession := &clickhousetest.MockSession{}
+	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+	err := store.Ping(context.Background())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mockSession.PingCalls != 1 {
+		t.Errorf("expected 1 Ping call, got %d", mockSession.PingCalls)
+	}
+}
+
+func TestClickHouseStore_Ping_Error(t *testing.T) {
+	mockSession := &clickhousetest.MockSession{
+		PingErr: errors.New("connection refused"),
+	}
+	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+	err := store.Ping(context.Background())
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "connection refused" {
+		t.Errorf("expected 'connection refused', got '%s'", err.Error())
+	}
+}

--- a/slippy/client.go
+++ b/slippy/client.go
@@ -245,6 +245,15 @@ func (c *Client) Store() SlipStore {
 	return c.store
 }
 
+// Ping verifies the underlying ClickHouse connection is alive.
+// This allows callers to detect stale pool connections before performing operations.
+func (c *Client) Ping(ctx context.Context) error {
+	if c.store == nil {
+		return fmt.Errorf("store is not initialized")
+	}
+	return c.store.Ping(ctx)
+}
+
 // GitHub returns the underlying GitHubAPI (useful for advanced operations).
 func (c *Client) GitHub() GitHubAPI {
 	return c.github

--- a/slippy/client_test.go
+++ b/slippy/client_test.go
@@ -591,3 +591,47 @@ func TestNewClient_ValidationErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_Ping(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{})
+
+		err := client.Ping(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if store.PingCalls != 1 {
+			t.Errorf("expected 1 Ping call, got %d", store.PingCalls)
+		}
+	})
+
+	t.Run("error propagation", func(t *testing.T) {
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{})
+
+		store.PingError = errors.New("connection dead")
+
+		err := client.Ping(context.Background())
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if err.Error() != "connection dead" {
+			t.Errorf("expected 'connection dead', got '%s'", err.Error())
+		}
+	})
+
+	t.Run("nil store", func(t *testing.T) {
+		client := &Client{store: nil}
+
+		err := client.Ping(context.Background())
+		if err == nil {
+			t.Fatal("expected error for nil store")
+		}
+		if !errors.Is(err, err) {
+			t.Error("expected non-nil error")
+		}
+	})
+}

--- a/slippy/interfaces.go
+++ b/slippy/interfaces.go
@@ -72,6 +72,10 @@ type SlipStore interface {
 
 	// Close releases any resources held by the store
 	Close() error
+
+	// Ping verifies the underlying database connection is alive.
+	// Returns nil if the connection is healthy, or an error if it is stale/dead.
+	Ping(ctx context.Context) error
 }
 
 // GitHubAPI defines the interface for GitHub operations.

--- a/slippy/mock_store_test.go
+++ b/slippy/mock_store_test.go
@@ -90,6 +90,10 @@ type MockStore struct {
 	AppendHistoryCalls    []AppendHistoryCall
 	CloseCalls            int
 
+	// Ping tracking and error injection
+	PingCalls int
+	PingError error
+
 	// Error injection for testing error paths
 	CreateError           error
 	LoadError             error
@@ -519,6 +523,15 @@ func (m *MockStore) Close() error {
 	}
 
 	return nil
+}
+
+// Ping verifies the database connection is alive (mock always returns PingError).
+func (m *MockStore) Ping(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.PingCalls++
+	return m.PingError
 }
 
 // Reset clears all stored data and call tracking.

--- a/slippy/mock_store_test.go
+++ b/slippy/mock_store_test.go
@@ -550,6 +550,7 @@ func (m *MockStore) Reset() {
 	m.UpdateComponentCalls = nil
 	m.AppendHistoryCalls = nil
 	m.CloseCalls = 0
+	m.PingCalls = 0
 }
 
 // AddSlip adds a slip directly to the store for testing.

--- a/slippy/slippytest/mock_store.go
+++ b/slippy/slippytest/mock_store.go
@@ -67,6 +67,10 @@ type MockStore struct {
 	AppendHistoryCalls    []AppendHistoryCall
 	CloseCalls            int
 
+	// Ping tracking and error injection
+	PingCalls int
+	PingError error
+
 	// Error injection for testing error paths
 	CreateError           error
 	LoadError             error
@@ -489,6 +493,15 @@ func (m *MockStore) Close() error {
 	return nil
 }
 
+// Ping verifies the database connection is alive (mock always returns PingError).
+func (m *MockStore) Ping(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.PingCalls++
+	return m.PingError
+}
+
 // Reset clears all stored data and call tracking.
 func (m *MockStore) Reset() {
 	m.mu.Lock()
@@ -506,6 +519,7 @@ func (m *MockStore) Reset() {
 	m.UpdateComponentCalls = nil
 	m.AppendHistoryCalls = nil
 	m.CloseCalls = 0
+	m.PingCalls = 0
 }
 
 // AddSlip adds a slip directly to the store for testing.


### PR DESCRIPTION
This pull request introduces a health check mechanism for ClickHouse connections throughout the codebase. The main change is the addition of a standardized `Ping` method to connection/session/store interfaces and their implementations, enabling clients to proactively verify that the database connection is alive before performing operations. Mock and test infrastructure have also been updated to support this new method. Additionally, connection pool settings are improved to reduce the risk of stale connections.

The most important changes are:

**Connection Health Checks:**

* Added a `Ping(ctx context.Context) error` method to the `ClickhouseSessionInterface`, `SlipStore` interface, and all their implementations (including mocks and test doubles), allowing callers to verify that the ClickHouse connection is alive. (`clickhouse/clickhouse.go`, `slippy/interfaces.go`, `slippy/clickhouse_store.go`, `slippy/client.go`, `clickhouse/clickhouse_test.go`, `clickhouse/clickhousetest/mock_session.go`, `slippy/mock_store_test.go`, `slippy/slippytest/mock_store.go`, `slippy/clickhouse_store_integration_test.go`) [[1]](diffhunk://#diff-9e92e66ee3d6b27a150ca3953172148ea342dd393c9baee9f966b03f302e74a3R96) [[2]](diffhunk://#diff-d77e7a58782cb13fce6ad350a2d8adcc561fd1c36188344f9d5406466eb99f07R75-R78) [[3]](diffhunk://#diff-485139025dfb68d519b37bee172fc83a7ec19e9772e13de46fcdc8ed3116178fR645-R649) [[4]](diffhunk://#diff-75562afd64d71ac504587fe04e820fed2b53b9f6b5d1bc462d5afebf66795c72R248-R256) [[5]](diffhunk://#diff-2e1c6aabb3f063bc616ea810b4f10215a84c7fcb727732ad36e1a825e956e55aR189-R193) [[6]](diffhunk://#diff-bf5e221eb4d996a12d9201450a130952606e0be8f5aeff09fbffa9e2ebed2b7aR49-R53) [[7]](diffhunk://#diff-bf5e221eb4d996a12d9201450a130952606e0be8f5aeff09fbffa9e2ebed2b7aR101-R109) [[8]](diffhunk://#diff-2a0a13a70081f68390d2c75b404fe10ca45864f3278f6246959832d76451fee8R93-R96) [[9]](diffhunk://#diff-2a0a13a70081f68390d2c75b404fe10ca45864f3278f6246959832d76451fee8R528-R536) [[10]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R70-R73) [[11]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R496-R504) [[12]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R522)

**Connection Pool Robustness:**

* Improved ClickHouse connection pool configuration in `ClickhouseSession.Connect` by setting `ConnMaxLifetime`, `MaxOpenConns`, `MaxIdleConns`, and enabling TCP keepalives via a custom `DialContext`. This reduces the risk of operations hanging due to stale connections. (`clickhouse/clickhouse.go`)

**Testing and Mocking Enhancements:**

* Updated all mock and test session/store types to implement the new `Ping` method, including call tracking and error injection for tests. (`clickhouse/clickhouse_test.go`, `clickhouse/clickhousetest/mock_session.go`, `slippy/mock_store_test.go`, `slippy/slippytest/mock_store.go`) [[1]](diffhunk://#diff-2e1c6aabb3f063bc616ea810b4f10215a84c7fcb727732ad36e1a825e956e55aR189-R193) [[2]](diffhunk://#diff-bf5e221eb4d996a12d9201450a130952606e0be8f5aeff09fbffa9e2ebed2b7aR49-R53) [[3]](diffhunk://#diff-bf5e221eb4d996a12d9201450a130952606e0be8f5aeff09fbffa9e2ebed2b7aR101-R109) [[4]](diffhunk://#diff-2a0a13a70081f68390d2c75b404fe10ca45864f3278f6246959832d76451fee8R93-R96) [[5]](diffhunk://#diff-2a0a13a70081f68390d2c75b404fe10ca45864f3278f6246959832d76451fee8R528-R536) [[6]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R70-R73) [[7]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R496-R504) [[8]](diffhunk://#diff-9469ddd4579399a77f9daa2f6702af44e295b7a2ff6d63bd0f4499aa5467c6b0R522)

**API Consistency:**

* Exposed the `Ping` method on the `Client` type, so callers can check connection health via the top-level API. (`slippy/client.go`)

**Dependency Update:**

* Added the `net` package import to support the custom `DialContext` for TCP keepalives. (`clickhouse/clickhouse.go`)