### PR TITLE
fix(slippy): scan state_history JSON column into *chcol.JSON for clickhouse-go v2.44.0 compat

### DIFF
--- a/.github/Gitversion.yml
+++ b/.github/Gitversion.yml
@@ -6,6 +6,7 @@ tag-prefix: '[vV]?'
 
 strategies:
   - TaggedCommit
+  - Fallback
 
 branches:
   main:
@@ -19,3 +20,25 @@ branches:
     track-merge-message: false
     is-release-branch: false
     is-main-branch: true
+  feature:
+    regex: ^feature[/-]
+    mode: ContinuousDelivery
+    label: '{BranchName}'
+    increment: Minor
+    prevent-increment:
+      of-merged-branch: false
+    track-merge-target: true
+    track-merge-message: true
+    is-release-branch: false
+    is-main-branch: false
+  hotfix:
+    regex: ^hotfix[/-]
+    mode: ContinuousDelivery
+    label: '{BranchName}'
+    increment: Patch
+    prevent-increment:
+      of-merged-branch: false
+    track-merge-target: true
+    track-merge-message: true
+    is-release-branch: false
+    is-main-branch: false

--- a/.github/Gitversion.yml
+++ b/.github/Gitversion.yml
@@ -6,7 +6,6 @@ tag-prefix: '[vV]?'
 
 strategies:
   - TaggedCommit
-  - Fallback
 
 branches:
   main:

--- a/.github/Gitversion.yml
+++ b/.github/Gitversion.yml
@@ -22,22 +22,18 @@ branches:
   feature:
     regex: ^feature[/-]
     mode: ContinuousDelivery
-    label: '{BranchName}'
+    label: pre
     increment: Minor
-    prevent-increment:
-      of-merged-branch: false
     track-merge-target: true
-    track-merge-message: true
+    track-merge-message: false
     is-release-branch: false
     is-main-branch: false
   hotfix:
     regex: ^hotfix[/-]
     mode: ContinuousDelivery
-    label: '{BranchName}'
+    label: pre
     increment: Patch
-    prevent-increment:
-      of-merged-branch: false
     track-merge-target: true
-    track-merge-message: true
+    track-merge-message: false
     is-release-branch: false
     is-main-branch: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,15 +280,21 @@ jobs:
         $(echo -e "$DOC_LIST")
         EOF
     - name: Create Release
-      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ steps.release_version.outputs.version }}
-        release_name: Release v${{ steps.release_version.outputs.version }}
-        body_path: release_body.md
-        draft: false
-        prerelease: ${{ steps.release_version.outputs.prerelease }}
+        VERSION: ${{ steps.release_version.outputs.version }}
+        PRERELEASE: ${{ steps.release_version.outputs.prerelease }}
+      run: |
+        if gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+          echo "Release v$VERSION already exists, skipping"
+        else
+          PRERELEASE_FLAG=""
+          [[ "$PRERELEASE" == "true" ]] && PRERELEASE_FLAG="--prerelease"
+          gh release create "v$VERSION" \
+            --title "Release v$VERSION" \
+            --notes-file release_body.md \
+            $PRERELEASE_FLAG
+        fi
 
     - name: Refresh pkg.go.dev cache for main module
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ on:
       - '!README.md'
     branches:
       - main
-  pull_request: 
+      - 'feature/**'
+      - 'hotfix/**'
+  pull_request:
     paths:
       - '**'
       - '!docs/**'
       - '!.github/**'
       - '!README.md'
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -66,7 +68,7 @@ jobs:
           profile: ./coverage-${{ matrix.module }}.out
           threshold-total: 75
           source-dir: ./${{ matrix.module }}
-      
+
   lint:
     name: lint-${{ matrix.module }}
     runs-on: ubuntu-latest
@@ -87,7 +89,7 @@ jobs:
         run: |
           go mod tidy
           golangci-lint run --config ../.github/.golangci.yml --timeout 5m ./...
-  
+
   vuln:
     name: check-sec-${{ matrix.module }}
     runs-on: ubuntu-latest
@@ -121,7 +123,7 @@ jobs:
           fi
           echo "All unit tests passed"
 
-  # Check that all lint jobs passed  
+  # Check that all lint jobs passed
   lint-check:
     name: "Lint status check"
     runs-on: ubuntu-latest
@@ -158,14 +160,17 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - discover
       - unit-tests-check
       - lint-check
       - vuln-check
-    if: github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/feature/') ||
+      startsWith(github.ref, 'refs/heads/hotfix/')
     outputs:
-      version: ${{ steps.calculate_version.outputs.majorMinorPatch }}
+      version: ${{ steps.calculate_version.outputs.semVer }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -187,16 +192,16 @@ jobs:
       id: create_tags
       env:
         MODULES: ${{ needs.discover.outputs.modules }}
-        VERSION: ${{ steps.calculate_version.outputs.majorMinorPatch }}
+        VERSION: ${{ steps.calculate_version.outputs.semVer }}
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-        
+
         # Create and push main library tag first
         echo "Creating main library tag v$VERSION"
         git tag -a "v$VERSION" -m "Release goLibMyCarrier v$VERSION"
         git push origin "v$VERSION"
-        
+
         # Create and push tags for each module dynamically
         MODULE_LIST=""
         for module in $(echo "$MODULES" | jq -r '.[]'); do
@@ -205,7 +210,7 @@ jobs:
           git push origin "$module/v$VERSION"
           MODULE_LIST="$MODULE_LIST- **$module** - $(head -1 $module/README.md 2>/dev/null | sed 's/^# //' || echo "$module package")\n"
         done
-        
+
         # Store module list for release notes
         echo "module_list<<EOF" >> $GITHUB_OUTPUT
         echo -e "$MODULE_LIST" >> $GITHUB_OUTPUT
@@ -214,7 +219,7 @@ jobs:
       id: release_body
       env:
         MODULES: ${{ needs.discover.outputs.modules }}
-        VERSION: ${{ steps.calculate_version.outputs.majorMinorPatch }}
+        VERSION: ${{ steps.calculate_version.outputs.semVer }}
       run: |
         # Generate package list for release notes
         PACKAGE_LIST=""
@@ -224,52 +229,60 @@ jobs:
           PACKAGE_LIST="$PACKAGE_LIST- **$module** - $DESC\n"
           DOC_LIST="$DOC_LIST- [$module](https://pkg.go.dev/github.com/MyCarrier-DevOps/goLibMyCarrier/$module@v$VERSION)\n"
         done
-        
+
         cat << EOF > release_body.md
         # goLibMyCarrier v$VERSION
-        
+
         This release includes updates to all Go packages in the goLibMyCarrier collection.
-        
+
         ## Packages Released
-        
+
         All packages have been tagged with version \`v$VERSION\`:
 
         $(echo -e "$PACKAGE_LIST")
-        
+
         ## Installation
-        
+
         Install any package using:
         \`\`\`bash
         go get github.com/MyCarrier-DevOps/goLibMyCarrier/<package>@v$VERSION
         \`\`\`
-        
+
         ## Documentation
-        
+
         View package documentation on pkg.go.dev:
         $(echo -e "$DOC_LIST")
         EOF
+    - name: Determine release type
+      id: release_type
+      run: |
+        if [[ -z "${{ steps.calculate_version.outputs.preReleaseLabel }}" ]]; then
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        else
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        fi
     - name: Create Release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ steps.calculate_version.outputs.majorMinorPatch }}
-        release_name: Release v${{ steps.calculate_version.outputs.majorMinorPatch }}
+        tag_name: v${{ steps.calculate_version.outputs.semVer }}
+        release_name: Release v${{ steps.calculate_version.outputs.semVer }}
         body_path: release_body.md
         draft: false
-        prerelease: false
-    
+        prerelease: ${{ steps.release_type.outputs.prerelease }}
+
     - name: Refresh pkg.go.dev cache for main module
       env:
-        VERSION: ${{ steps.calculate_version.outputs.majorMinorPatch }}
+        VERSION: ${{ steps.calculate_version.outputs.semVer }}
       run: |
         # Request pkg.go.dev to fetch the new main module version
         echo "Requesting pkg.go.dev refresh for main module v$VERSION"
         curl -s "https://proxy.golang.org/github.com/!my!carrier-!dev!ops/go!lib!my!carrier/@v/v$VERSION.info" || true
-        
+
         # Give the proxy a moment to process
         sleep 2
-        
+
         # Trigger documentation generation for main module
         echo "Triggering pkg.go.dev documentation for main module"
         curl -s "https://pkg.go.dev/github.com/MyCarrier-DevOps/goLibMyCarrier@v$VERSION" > /dev/null || true
@@ -293,16 +306,16 @@ jobs:
         run: |
           # Convert module path to Go module proxy format (uppercase letters become !lowercase)
           ENCODED_MODULE=$(echo "$MODULE" | sed 's/\([A-Z]\)/!\L\1/g')
-          
+
           # Request pkg.go.dev to fetch the submodule version via Go proxy
           echo "Requesting pkg.go.dev refresh for $MODULE/v$VERSION"
           curl -s "https://proxy.golang.org/github.com/!my!carrier-!dev!ops/go!lib!my!carrier/$ENCODED_MODULE/@v/v$VERSION.info" || true
-          
+
           # Give the proxy a moment to process
           sleep 2
-          
+
           # Trigger documentation generation for the submodule
           echo "Triggering pkg.go.dev documentation for $MODULE"
           curl -s "https://pkg.go.dev/github.com/MyCarrier-DevOps/goLibMyCarrier/$MODULE@v$VERSION" > /dev/null || true
-          
+
           echo "pkg.go.dev refresh completed for $MODULE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,9 @@ jobs:
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+        # Fetch all remote tags so local rev-parse checks are accurate
+        git fetch --tags --quiet
+
         # Create and push main library tag (idempotent: skip if already exists)
         if git rev-parse -q --verify "refs/tags/v$VERSION" > /dev/null 2>&1; then
           echo "Tag v$VERSION already exists, skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - '!docs/**'
       - '!.github/**'
       - '!README.md'
+      - '.github/workflows/ci.yml'
+      - '.github/Gitversion.yml'
     branches:
       - main
       - 'feature/**'
@@ -17,6 +19,8 @@ on:
       - '!docs/**'
       - '!.github/**'
       - '!README.md'
+      - '.github/workflows/ci.yml'
+      - '.github/Gitversion.yml'
     branches:
       - main
 
@@ -170,7 +174,7 @@ jobs:
       startsWith(github.ref, 'refs/heads/feature/') ||
       startsWith(github.ref, 'refs/heads/hotfix/')
     outputs:
-      version: ${{ steps.calculate_version.outputs.semVer }}
+      version: ${{ steps.release_version.outputs.version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -188,26 +192,48 @@ jobs:
         useConfigFile: true
         disableCache: true
         configFilePath: .github/Gitversion.yml
+    - name: Compute release version
+      id: release_version
+      run: |
+        BASE="${{ steps.calculate_version.outputs.majorMinorPatch }}"
+        if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+          echo "version=$BASE" >> $GITHUB_OUTPUT
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        else
+          LABEL=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|g' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+          COUNT=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "1")
+          [[ -z "$COUNT" || "$COUNT" == "0" ]] && COUNT=1
+          echo "version=${BASE}-${LABEL}.${COUNT}" >> $GITHUB_OUTPUT
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        fi
     - name: Create and push tags
       id: create_tags
       env:
         MODULES: ${{ needs.discover.outputs.modules }}
-        VERSION: ${{ steps.calculate_version.outputs.semVer }}
+        VERSION: ${{ steps.release_version.outputs.version }}
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-        # Create and push main library tag first
-        echo "Creating main library tag v$VERSION"
-        git tag -a "v$VERSION" -m "Release goLibMyCarrier v$VERSION"
-        git push origin "v$VERSION"
+        # Create and push main library tag (idempotent: skip if already exists)
+        if git rev-parse -q --verify "refs/tags/v$VERSION" > /dev/null 2>&1; then
+          echo "Tag v$VERSION already exists, skipping"
+        else
+          echo "Creating main library tag v$VERSION"
+          git tag -a "v$VERSION" -m "Release goLibMyCarrier v$VERSION"
+          git push origin "v$VERSION"
+        fi
 
-        # Create and push tags for each module dynamically
+        # Create and push tags for each module dynamically (idempotent)
         MODULE_LIST=""
         for module in $(echo "$MODULES" | jq -r '.[]'); do
-          echo "Creating tag for $module/v$VERSION"
-          git tag -a "$module/v$VERSION" -m "Release $module/v$VERSION"
-          git push origin "$module/v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$module/v$VERSION" > /dev/null 2>&1; then
+            echo "Tag $module/v$VERSION already exists, skipping"
+          else
+            echo "Creating tag for $module/v$VERSION"
+            git tag -a "$module/v$VERSION" -m "Release $module/v$VERSION"
+            git push origin "$module/v$VERSION"
+          fi
           MODULE_LIST="$MODULE_LIST- **$module** - $(head -1 $module/README.md 2>/dev/null | sed 's/^# //' || echo "$module package")\n"
         done
 
@@ -219,7 +245,7 @@ jobs:
       id: release_body
       env:
         MODULES: ${{ needs.discover.outputs.modules }}
-        VERSION: ${{ steps.calculate_version.outputs.semVer }}
+        VERSION: ${{ steps.release_version.outputs.version }}
       run: |
         # Generate package list for release notes
         PACKAGE_LIST=""
@@ -253,28 +279,20 @@ jobs:
         View package documentation on pkg.go.dev:
         $(echo -e "$DOC_LIST")
         EOF
-    - name: Determine release type
-      id: release_type
-      run: |
-        if [[ -z "${{ steps.calculate_version.outputs.preReleaseLabel }}" ]]; then
-          echo "prerelease=false" >> $GITHUB_OUTPUT
-        else
-          echo "prerelease=true" >> $GITHUB_OUTPUT
-        fi
     - name: Create Release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ steps.calculate_version.outputs.semVer }}
-        release_name: Release v${{ steps.calculate_version.outputs.semVer }}
+        tag_name: v${{ steps.release_version.outputs.version }}
+        release_name: Release v${{ steps.release_version.outputs.version }}
         body_path: release_body.md
         draft: false
-        prerelease: ${{ steps.release_type.outputs.prerelease }}
+        prerelease: ${{ steps.release_version.outputs.prerelease }}
 
     - name: Refresh pkg.go.dev cache for main module
       env:
-        VERSION: ${{ steps.calculate_version.outputs.semVer }}
+        VERSION: ${{ steps.release_version.outputs.version }}
       run: |
         # Request pkg.go.dev to fetch the new main module version
         echo "Requesting pkg.go.dev refresh for main module v$VERSION"

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	ch "github.com/MyCarrier-DevOps/goLibMyCarrier/clickhouse"
 	"github.com/MyCarrier-DevOps/goLibMyCarrier/clickhousemigrator"
 )
@@ -913,14 +914,18 @@ func (s *ClickHouseStore) loadStateHistoryFromDB(ctx context.Context, correlatio
 	`, s.database, TableRoutingSlips, ColumnCorrelationID, ColumnSign, ColumnVersion)
 
 	row := s.session.QueryRow(ctx, query, correlationID)
-	var historyJSON string
-	if err := row.Scan(&historyJSON); err != nil {
+	historyCol := chcol.NewJSON()
+	if err := row.Scan(historyCol); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", fmt.Errorf("%w: correlation_id=%s", ErrSlipNotFound, correlationID)
 		}
 		return "", fmt.Errorf("failed to load state_history for %s: %w", correlationID, err)
 	}
-	return historyJSON, nil
+	jsonBytes, err := historyCol.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal state_history for %s: %w", correlationID, err)
+	}
+	return string(jsonBytes), nil
 }
 
 // insertAtomicHistoryUpdate cancels all active routing_slips rows for correlationID and inserts

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -915,6 +915,9 @@ func (s *ClickHouseStore) loadStateHistoryFromDB(ctx context.Context, correlatio
 	`, s.database, TableRoutingSlips, ColumnCorrelationID, ColumnSign, ColumnVersion)
 
 	row := s.session.QueryRow(ctx, query, correlationID)
+	if row == nil {
+		return "", fmt.Errorf("failed to load state_history for %s: query returned nil row", correlationID)
+	}
 	historyCol := chcol.NewJSON()
 	if err := row.Scan(historyCol); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+
 	ch "github.com/MyCarrier-DevOps/goLibMyCarrier/clickhouse"
 	"github.com/MyCarrier-DevOps/goLibMyCarrier/clickhousemigrator"
 )

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -2422,16 +2422,33 @@ func TestClickHouseStore_Ping_Error(t *testing.T) {
 // the DB row rather than an in-memory snapshot.
 func TestClickHouseStore_AppendHistory_DoesNotCallFullLoad(t *testing.T) {
 	mockSession := &clickhousetest.MockSession{
-		QueryRowRow: &clickhousetest.MockRow{
-			ScanFunc: func(dest ...any) error {
-				if len(dest) < 1 {
-					return fmt.Errorf("expected at least 1 scan destination, got 0")
+		QueryRowFunc: func(ctx context.Context, query string, args ...any) driver.Row {
+			if strings.Contains(query, "SELECT state_history") {
+				// Strict: destination must be *chcol.JSON and Scan error must propagate.
+				return &clickhousetest.MockRow{
+					ScanFunc: func(dest ...any) error {
+						if len(dest) < 1 {
+							return fmt.Errorf("expected at least 1 scan destination, got 0")
+						}
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]interface{}{"entries": []interface{}{}})
+					},
 				}
-				if jsonPtr, ok := dest[0].(*chcol.JSON); ok {
-					_ = jsonPtr.Scan(map[string]interface{}{"entries": []interface{}{}})
-				}
-				return nil
-			},
+			}
+			// loadVersionFromDB: SELECT version FROM ...
+			return &clickhousetest.MockRow{
+				ScanFunc: func(dest ...any) error {
+					if len(dest) > 0 {
+						if v, ok := dest[0].(*uint64); ok {
+							*v = 1
+						}
+					}
+					return nil
+				},
+			}
 		},
 	}
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
@@ -3276,12 +3293,14 @@ func TestClickHouseStore_AppendHistory_InsertAtomicHistoryUpdateError(t *testing
 			// loadStateHistoryFromDB succeeds
 			return &clickhousetest.MockRow{
 				ScanFunc: func(dest ...any) error {
-					if len(dest) > 0 {
-						if jsonPtr, ok := dest[0].(*chcol.JSON); ok {
-							_ = jsonPtr.Scan(map[string]interface{}{"entries": []interface{}{}})
-						}
+					if len(dest) == 0 {
+						return fmt.Errorf("expected scan destination, got none")
 					}
-					return nil
+					jsonPtr, ok := dest[0].(*chcol.JSON)
+					if !ok {
+						return fmt.Errorf("expected *chcol.JSON destination, got %T", dest[0])
+					}
+					return jsonPtr.Scan(map[string]any{"entries": []any{}})
 				},
 			}
 		},

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -2421,15 +2421,14 @@ func TestClickHouseStore_Ping_Error(t *testing.T) {
 // one ExecWithArgs (insertAtomicHistoryUpdate), keeping all step/aggregate columns in sync with
 // the DB row rather than an in-memory snapshot.
 func TestClickHouseStore_AppendHistory_DoesNotCallFullLoad(t *testing.T) {
-	stateHistoryJSON := `{"entries":[]}`
 	mockSession := &clickhousetest.MockSession{
 		QueryRowRow: &clickhousetest.MockRow{
 			ScanFunc: func(dest ...any) error {
 				if len(dest) < 1 {
 					return fmt.Errorf("expected at least 1 scan destination, got 0")
 				}
-				if ptr, ok := dest[0].(*string); ok {
-					*ptr = stateHistoryJSON
+				if jsonPtr, ok := dest[0].(*chcol.JSON); ok {
+					_ = jsonPtr.Scan(map[string]interface{}{"entries": []interface{}{}})
 				}
 				return nil
 			},
@@ -3277,8 +3276,10 @@ func TestClickHouseStore_AppendHistory_InsertAtomicHistoryUpdateError(t *testing
 			// loadStateHistoryFromDB succeeds
 			return &clickhousetest.MockRow{
 				ScanFunc: func(dest ...any) error {
-					if ptr, ok := dest[0].(*string); ok {
-						*ptr = `{"entries":[]}`
+					if len(dest) > 0 {
+						if jsonPtr, ok := dest[0].(*chcol.JSON); ok {
+							_ = jsonPtr.Scan(map[string]interface{}{"entries": []interface{}{}})
+						}
 					}
 					return nil
 				},
@@ -3731,11 +3732,17 @@ func TestClickHouseStore_AppendHistory_ContextCancelled(t *testing.T) {
 func TestClickHouseStore_AppendHistory_MalformedHistoryJSON(t *testing.T) {
 	mockSession := &clickhousetest.MockSession{
 		QueryRowFunc: func(ctx context.Context, query string, args ...any) driver.Row {
-			// With clickhouse-go v2.44.0+, scanning a JSON column into *chcol.JSON;
-			// malformed JSON is rejected at scan time by the driver — simulate that.
+			// Populate *chcol.JSON with malformed JSON so the error is caught downstream
+			// at unmarshal time (json.Unmarshal in AppendHistory), matching the real
+			// production scenario where the column contains corrupt data.
 			return &clickhousetest.MockRow{
 				ScanFunc: func(dest ...any) error {
-					return fmt.Errorf("clickhouse: malformed JSON in state_history: not-valid-json{")
+					for _, d := range dest {
+						if jsonPtr, ok := d.(*chcol.JSON); ok {
+							return jsonPtr.Scan("not-valid-json{")
+						}
+					}
+					return fmt.Errorf("expected *chcol.JSON destination for state_history scan")
 				},
 			}
 		},

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -851,12 +851,14 @@ func createMockSessionForUpdates(
 			if strings.Contains(query, "SELECT state_history") {
 				return &clickhousetest.MockRow{
 					ScanFunc: func(dest ...any) error {
-						if len(dest) > 0 {
-							if ptr, ok := dest[0].(*string); ok {
-								*ptr = `{"entries":[]}`
-							}
+						if len(dest) == 0 {
+							return fmt.Errorf("expected scan destination, got none")
 						}
-						return nil
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]any{"entries": []any{}})
 					},
 				}
 			}
@@ -2914,12 +2916,14 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ConflictRetry(t *testi
 			if strings.Contains(query, "SELECT state_history") {
 				return &clickhousetest.MockRow{
 					ScanFunc: func(dest ...any) error {
-						if len(dest) > 0 {
-							if ptr, ok := dest[0].(*string); ok {
-								*ptr = `{"entries":[]}`
-							}
+						if len(dest) == 0 {
+							return fmt.Errorf("expected scan destination, got none")
 						}
-						return nil
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]any{"entries": []any{}})
 					},
 				}
 			}
@@ -3006,12 +3010,14 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ConflictRetryExhausted
 			if strings.Contains(query, "SELECT state_history") {
 				return &clickhousetest.MockRow{
 					ScanFunc: func(dest ...any) error {
-						if len(dest) > 0 {
-							if ptr, ok := dest[0].(*string); ok {
-								*ptr = `{"entries":[]}`
-							}
+						if len(dest) == 0 {
+							return fmt.Errorf("expected scan destination, got none")
 						}
-						return nil
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]any{"entries": []any{}})
 					},
 				}
 			}
@@ -3751,17 +3757,11 @@ func TestClickHouseStore_AppendHistory_ContextCancelled(t *testing.T) {
 func TestClickHouseStore_AppendHistory_MalformedHistoryJSON(t *testing.T) {
 	mockSession := &clickhousetest.MockSession{
 		QueryRowFunc: func(ctx context.Context, query string, args ...any) driver.Row {
-			// Populate *chcol.JSON with malformed JSON so the error is caught downstream
-			// at unmarshal time (json.Unmarshal in AppendHistory), matching the real
-			// production scenario where the column contains corrupt data.
+			// Return a scan-time error simulating how clickhouse-go v2.44.0 rejects
+			// malformed JSON at row.Scan, matching the real production failure mode.
 			return &clickhousetest.MockRow{
 				ScanFunc: func(dest ...any) error {
-					for _, d := range dest {
-						if jsonPtr, ok := d.(*chcol.JSON); ok {
-							return jsonPtr.Scan("not-valid-json{")
-						}
-					}
-					return fmt.Errorf("expected *chcol.JSON destination for state_history scan")
+					return fmt.Errorf("clickhouse: failed to scan JSON column: invalid JSON data")
 				},
 			}
 		},
@@ -4190,10 +4190,14 @@ func TestClickHouseStore_AppendHistory_ConflictRetry(t *testing.T) {
 				mu.Unlock()
 				return &clickhousetest.MockRow{
 					ScanFunc: func(dest ...any) error {
-						if ptr, ok := dest[0].(*string); ok {
-							*ptr = `{"entries":[]}`
+						if len(dest) == 0 {
+							return fmt.Errorf("expected scan destination, got none")
 						}
-						return nil
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]any{"entries": []any{}})
 					},
 				}
 			}
@@ -4299,10 +4303,14 @@ func TestClickHouseStore_AppendHistory_ConflictRetryExhausted(t *testing.T) {
 				mu.Unlock()
 				return &clickhousetest.MockRow{
 					ScanFunc: func(dest ...any) error {
-						if ptr, ok := dest[0].(*string); ok {
-							*ptr = `{"entries":[]}`
+						if len(dest) == 0 {
+							return fmt.Errorf("expected scan destination, got none")
 						}
-						return nil
+						jsonPtr, ok := dest[0].(*chcol.JSON)
+						if !ok {
+							return fmt.Errorf("expected dest[0] to be *chcol.JSON, got %T", dest[0])
+						}
+						return jsonPtr.Scan(map[string]any{"entries": []any{}})
 					},
 				}
 			}

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -3731,13 +3731,11 @@ func TestClickHouseStore_AppendHistory_ContextCancelled(t *testing.T) {
 func TestClickHouseStore_AppendHistory_MalformedHistoryJSON(t *testing.T) {
 	mockSession := &clickhousetest.MockSession{
 		QueryRowFunc: func(ctx context.Context, query string, args ...any) driver.Row {
-			// loadStateHistoryFromDB returns successfully but with garbage JSON.
+			// With clickhouse-go v2.44.0+, scanning a JSON column into *chcol.JSON;
+			// malformed JSON is rejected at scan time by the driver — simulate that.
 			return &clickhousetest.MockRow{
 				ScanFunc: func(dest ...any) error {
-					if ptr, ok := dest[0].(*string); ok {
-						*ptr = "not-valid-json{"
-					}
-					return nil
+					return fmt.Errorf("clickhouse: malformed JSON in state_history: not-valid-json{")
 				},
 			}
 		},


### PR DESCRIPTION
## Issue

After updating Slippy CLI to goLibMyCarrier `v1.3.71` (PR [Slippy#10](https://github.com/MyCarrier-DevOps/Slippy/pull/10)), the pre-job step failed with:

```
pre-job failed: failed to set held status for step dev_deploy: update step dev_deploy on slip 7fe9c332-52da-47ae-bd21-ae2691ba1357: failed to load state_history for 7fe9c332-52da-47ae-bd21-ae2691ba1357: clickhouse []: destination must be a pointer to struct or map, or chcol.JSON. hint: enable &#34;output_format_native_write_json_as_string&#34; setting for string decoding
ERROR: slippy pre-job failed
```

## Root Cause

`clickhouse-go` was bumped **v2.42.0 → v2.44.0** in goLibMyCarrier v1.3.70 (commit `994ecd5`). The new driver version no longer allows scanning a `JSON`-typed ClickHouse column into a plain `*string` — it requires `*chcol.JSON`, a struct, or a map.

`scanner.go` was already correctly migrated to `chcol.NewJSON()` at v1.3.64, but `loadStateHistoryFromDB` — the separate single-column `SELECT state_history` query executed by the pre-job **&#34;set held status&#34;** code path (`AppendHistory` → `insertAtomicHistoryUpdate`) — was missed:

```go
// ❌ Before — breaks with clickhouse-go v2.44.0
var historyJSON string
if err := row.Scan(&historyJSON); err != nil { ... }
```

## Fix

- Add `chcol` import to `clickhouse_store.go`
- Scan `state_history` into `*chcol.JSON`, then marshal to `string` — consistent with the pattern already used in `scanner.go`
- Update `TestClickHouseStore_AppendHistory_MalformedHistoryJSON`: mock `ScanFunc` returns a scan-time error directly, simulating clickhouse-go v2.44.0 behavior where the driver rejects malformed JSON at `row.Scan`

```go
// ✅ After
historyCol := chcol.NewJSON()
if err := row.Scan(historyCol); err != nil { ... }
jsonBytes, err := historyCol.MarshalJSON()
```

## Files Changed

| File | Change |
|------|--------|
| `slippy/clickhouse_store.go` | Add `chcol` import; fix `loadStateHistoryFromDB` scan destination |
| `slippy/clickhouse_store_unit_test.go` | Update all affected `ScanFunc` mocks to assert `*chcol.JSON` destination and populate via `jsonPtr.Scan(...)`; malformed-JSON test now returns a scan-time error |

---

## CI: Beta versioning from branches

This PR also introduces pre-release version publishing from `feature/**` and `hotfix/**` branches, enabling downstream consumers (e.g. Slippy CLI) to test library changes before they land on `main`.

### Changes

#### `.github/Gitversion.yml`
- Added `feature` branch config: `Minor` increment, static label `pre` — GitVersion calculates `majorMinorPatch`, the workflow derives the full pre-release version string in shell
- Added `hotfix` branch config: `Patch` increment, same approach
- Note: `{BranchName}` label template was intentionally avoided — GitVersion v6 logs the template string to stdout (interleaved with JSON output), causing the `gittools/actions` wrapper to fail parsing at `Expected property name or '}' at position 1`

#### `.github/workflows/ci.yml`

| What | Detail |
|------|--------|
| `on.push.branches` | Now triggers on `feature/**` and `hotfix/**` in addition to `main` |
| `on.push.paths` / `on.pull_request.paths` | Re-included `.github/workflows/ci.yml` and `.github/Gitversion.yml` after the `!.github/**` exclusion so CI/versioning config changes trigger the pipeline |
| `release` job `if` | Fires for `main`, `feature/**`, and `hotfix/**` branch pushes; PR events still skip it (`refs/pull/N/merge`) |
| `Compute release version` step | Derives full version in shell: on `main` → `majorMinorPatch`; on branches → `{majorMinorPatch}-{sanitized-branch-name}.{commits-ahead-of-main}` |
| Tag creation | `git fetch --tags` before guards; both root and per-module tags wrapped with `git rev-parse -q --verify` existence check — idempotent on re-runs |
| `Create Release` | Replaced `actions/create-release@v1` (which always errors on `422 already_exists`) with `gh release create` guarded by `gh release view` — idempotent on re-runs |

### How to consume a beta tag

```bash
go get github.com/MyCarrier-DevOps/goLibMyCarrier/slippy@v1.3.72-hotfix-clickhouse-go.9
```

Pre-release GitHub Releases are marked as pre-release and do not affect the "latest release" pointer.