### PR TITLE
fix(slippy): exclude terminal slips from FindByCommits and handlePushRetry

### DIFF
--- a/slippy/push.go
+++ b/slippy/push.go
@@ -162,7 +162,7 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 
 	// Check for existing slip (retry detection)
 	existingSlip, err := c.store.LoadByCommit(ctx, opts.Repository, opts.CommitSHA)
-	if err == nil && existingSlip != nil {
+	if err == nil && existingSlip != nil && !existingSlip.Status.IsTerminal() {
 		slip, err := c.handlePushRetry(ctx, existingSlip)
 		if err != nil {
 			return nil, err

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -142,6 +142,14 @@ type CreateSlipResult struct {
 // finds any existing slips for ancestor commits, and ensures they are
 // in a terminal state (abandoning non-terminal slips that are being superseded).
 //
+// Retry vs new-slip behavior for the same commit SHA:
+//   - If an existing slip is found and is non-terminal (in_progress, failed, etc.),
+//     it is retried via handlePushRetry (same correlation ID is reused).
+//   - If an existing slip is found and is terminal (abandoned, promoted, compensated,
+//     completed), it is treated as stale and a fresh slip is created with the new
+//     correlation ID from opts. This prevents resurrecting superseded slips on
+//     webhook re-delivery or bot-commit races.
+//
 // The returned CreateSlipResult contains both the slip and any non-fatal errors
 // that occurred during processing (e.g., ancestry resolution failures).
 // Callers should check Warnings for issues that didn't prevent slip creation

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -226,6 +226,65 @@ func TestClient_CreateSlipForPush(t *testing.T) {
 		}
 	})
 
+	t.Run("new slip for terminal existing slip", func(t *testing.T) {
+		// When a terminal slip (abandoned, promoted, compensated, completed) already
+		// exists for the commit SHA, CreateSlipForPush must NOT call handlePushRetry.
+		// Instead it falls through and creates a fresh slip with the new correlation ID.
+		// This prevents webhook re-delivery or bot-commit races from resurrecting stale slips.
+		for _, termStatus := range []SlipStatus{
+			SlipStatusAbandoned, SlipStatusPromoted, SlipStatusCompensated, SlipStatusCompleted,
+		} {
+			termStatus := termStatus
+			t.Run(string(termStatus), func(t *testing.T) {
+				store := NewMockStore()
+				github := NewMockGitHubAPI()
+				config := testPipelineConfig()
+				client := NewClientWithDependencies(store, github, Config{PipelineConfig: config})
+
+				// Pre-create terminal slip for the same commit
+				store.AddSlip(&Slip{
+					CorrelationID: "corr-terminal-old",
+					Repository:    "owner/repo",
+					Branch:        "main",
+					CommitSHA:     "terminal-commit-abc",
+					Status:        termStatus,
+					Steps:         map[string]Step{},
+					StateHistory:  []StateHistoryEntry{},
+				})
+
+				opts := PushOptions{
+					CorrelationID: "corr-new-after-terminal",
+					Repository:    "owner/repo",
+					Branch:        "main",
+					CommitSHA:     "terminal-commit-abc",
+					Components:    []ComponentDefinition{},
+				}
+
+				result, err := client.CreateSlipForPush(ctx, opts)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				// Must return the NEW slip, not the terminal one
+				if result.Slip.CorrelationID != "corr-new-after-terminal" {
+					t.Errorf("expected new slip ID 'corr-new-after-terminal', got '%s'", result.Slip.CorrelationID)
+				}
+
+				// Exactly one Create call for the new slip
+				if len(store.CreateCalls) != 1 {
+					t.Errorf("expected 1 Create call for new slip, got %d", len(store.CreateCalls))
+				}
+
+				// handlePushRetry resets push_parsed to running — must NOT have happened
+				for _, call := range store.UpdateStepCalls {
+					if call.StepName == "push_parsed" && call.Status == StepStatusRunning {
+						t.Error("handlePushRetry must not be called for a terminal existing slip")
+					}
+				}
+			})
+		}
+	})
+
 	t.Run("validation error", func(t *testing.T) {
 		store := NewMockStore()
 		github := NewMockGitHubAPI()

--- a/slippy/query_builder.go
+++ b/slippy/query_builder.go
@@ -117,6 +117,7 @@ func (b *SlipQueryBuilder) BuildFindByCommitsQuery() string {
 		INNER JOIN commits c ON s.commit_sha = c.commit_sha
 		WHERE lower(s.repository) = lower({repository:String})
 		  AND s.sign = 1
+		  AND s.status NOT IN ('abandoned', 'promoted', 'compensated')
 		ORDER BY c.priority ASC, s.version DESC
 		LIMIT 1
 	`, selectColumns, b.database)

--- a/slippy/query_builder.go
+++ b/slippy/query_builder.go
@@ -101,6 +101,13 @@ func (b *SlipQueryBuilder) AggregateColumn(stepName string) string {
 // BuildFindByCommitsQuery builds a query to find a slip by a list of commits.
 // Only selects active rows (sign=1) to exclude orphaned cancel rows.
 // Repository comparison is case-insensitive to handle variations in repository naming.
+//
+// The status filter excludes superseded terminal statuses: abandoned (replaced by a newer push),
+// promoted (squash-merged feature branch), and compensated (compensation completed). These slips
+// are stale and must not be returned to callers looking for the active slip.
+//
+// Intentionally NOT excluded: completed (CI ran successfully — still a valid lookup target for
+// history and reporting) and failed (non-terminal — eligible for retry resolution).
 func (b *SlipQueryBuilder) BuildFindByCommitsQuery() string {
 	selectColumns := b.BuildSelectColumnsWithPrefix("s.")
 

--- a/slippy/query_builder_test.go
+++ b/slippy/query_builder_test.go
@@ -219,6 +219,16 @@ func TestSlipQueryBuilder_BuildFindByCommitsQuery(t *testing.T) {
 	if !strings.Contains(query, "LIMIT 1") {
 		t.Error("query should have LIMIT 1")
 	}
+	// Superseded terminal statuses must be excluded so stale abandoned/promoted/compensated
+	// slips are never returned to callers looking for an active slip.
+	if !strings.Contains(query, "s.status NOT IN") {
+		t.Error("query should filter out superseded terminal statuses (abandoned, promoted, compensated)")
+	}
+	// completed and failed must remain visible — completed is a valid historical result,
+	// failed is non-terminal and eligible for retry resolution.
+	if strings.Contains(query, "'completed'") {
+		t.Error("query must NOT exclude 'completed' — completed slips are valid FindByCommits results")
+	}
 }
 
 func TestSlipQueryBuilder_BuildFindAllByCommitsQuery(t *testing.T) {
@@ -240,6 +250,11 @@ func TestSlipQueryBuilder_BuildFindAllByCommitsQuery(t *testing.T) {
 	// Should NOT have LIMIT 1 (unlike BuildFindByCommitsQuery)
 	if strings.Contains(query, "LIMIT 1") {
 		t.Error("BuildFindAllByCommitsQuery should NOT have LIMIT 1")
+	}
+	// Must NOT have the status filter — ancestry search intentionally returns all statuses
+	// (including abandoned/promoted) to build the full lineage chain.
+	if strings.Contains(query, "s.status NOT IN") {
+		t.Error("BuildFindAllByCommitsQuery must NOT filter by status — ancestry search needs all slips")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix two related bugs in the slippy package that caused E2E integration tests to resolve stale abandoned correlation IDs instead of active ones.

- **Fix 1** — `BuildFindByCommitsQuery` was returning abandoned/promoted/compensated slips to all resolution callers. Added `AND s.status NOT IN ('abandoned', 'promoted', 'compensated')` filter. `BuildFindAllByCommitsQuery` is intentionally unchanged (ancestry chain requires all statuses).
- **Fix 3** — `handlePushRetry` was unconditionally resurrecting terminal slips on webhook re-delivery. Guarded with `!existingSlip.Status.IsTerminal()` so terminal slips fall through to fresh slip creation instead.

## Affected callers of FindByCommits (singular)

| Caller | Effect |
|---|---|
| `goLibMyCarrier/slippy/resolve.go` — `ResolveSlip()` | Now skips terminal ancestors |
| `slippy-api` — `POST /slips/find-by-commits` | Returns active slip only |
| `slippy-find` CLI | Returns active slip only |
| `BuildFindAllByCommitsQuery` (ancestry chain in `push.go`) | **Not changed** — intentionally returns all statuses |

## How to verify

1. Create a slip for commit A, then abandon it (simulate via a superseding push or `AbandonSlip`)
2. Call `POST /slips/find-by-commits` with commit A — should return `ErrSlipNotFound`, not the abandoned slip
3. Re-deliver the webhook for commit A whose slip is abandoned — should create a *new* slip, not resurrect the old one
4. Run E2E integration tests in workflow-dev against MC.Example — correlation ID resolution should always return the active slip

## Related

- pushhookparser PR #31 — upstream fix preventing spurious slip creation for bot commits when `AllowSlipWithNoBuilds=true`
- `workflow-dev/.github/scripts/resolve_correlation_id.py` — Fix 2 (already shipped, same status filter on direct ClickHouse path)
- Full RCA: `slippy/RCA_CORRELATION_ID_STALE_ABANDONED_SLIP.md`

## Checklist
- [x] Build passes
- [x] All tests pass (`go test ./...` — both `slippy` and `slippy/slippytest` packages)
- [x] `BuildFindAllByCommitsQuery` deliberately NOT filtered (ancestry search requires all statuses)
- [x] No secrets or credentials committed
