### PR TITLE
fix(slippy): do not abandon cross-branch ancestor slips

### DIFF
--- a/slippy/push.go
+++ b/slippy/push.go
@@ -330,7 +330,8 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 		// the same commit, they would re-run without pushing and the non-terminal
 		// slip would be found by ancestry resolution.
 		if i == 0 && !slip.Status.IsTerminal() {
-			if isSquashMerge {
+			switch {
+			case isSquashMerge:
 				// Squash merge: promote the feature branch slip (successful outcome).
 				// Cross-branch promotion is expected here — the ancestor is on the
 				// feature branch being merged into the current branch.
@@ -355,21 +356,23 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 					// Update the local copy to reflect the promotion
 					slip.Status = SlipStatusPromoted
 				}
-			} else if slip.Branch != opts.Branch {
+
+			case opts.Branch != "" && slip.Branch != "" && slip.Branch != opts.Branch:
 				// Cross-branch ancestor found via shared git history (e.g. a push to
 				// "main" whose ancestry walks through commits that also exist on
-				// "integration"). Do NOT abandon the slip — it belongs to a different
-				// branch and is still actively in-flight there. Record it in the
-				// ancestry chain for history but leave its status untouched.
+				// "integration"). Only skip abandonment when both branch values are
+				// known and different; otherwise preserve existing abandonment
+				// behavior for slips with missing branch metadata.
 				c.logger.Info(ctx, "Skipping cross-branch ancestor slip (different branch)", map[string]interface{}{
-					"ancestor_id":      slip.CorrelationID,
-					"ancestor_branch":  slip.Branch,
-					"ancestor_commit":  shortSHA(slip.CommitSHA),
-					"ancestor_status":  string(slip.Status),
-					"current_branch":   opts.Branch,
+					"ancestor_id":        slip.CorrelationID,
+					"ancestor_branch":    slip.Branch,
+					"ancestor_commit":    shortSHA(slip.CommitSHA),
+					"ancestor_status":    string(slip.Status),
+					"current_branch":     opts.Branch,
 					"superseding_commit": shortSHA(opts.CommitSHA),
 				})
-			} else {
+
+			default:
 				// Regular push on the same branch: abandon the superseded slip.
 				c.logger.Info(ctx, "Abandoning superseded slip", map[string]interface{}{
 					"superseded_id":      slip.CorrelationID,

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -300,7 +300,13 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 	// For squash merges: promote the feature branch slip
 	// For regular pushes: abandon non-terminal ancestor slips
 	var ancestry []AncestryEntry
-	for i, ancestorSlip := range ancestorSlips {
+	// handledAncestor tracks whether we have already promoted or abandoned an
+	// ancestor slip.  We use this instead of checking i == 0 so that a
+	// cross-branch slip that happens to sit at index 0 (because it shares a
+	// more-recent commit SHA with another branch) does not block abandonment of
+	// the first eligible same-branch non-terminal slip found later in the list.
+	handledAncestor := false
+	for _, ancestorSlip := range ancestorSlips {
 		slip := ancestorSlip.Slip
 
 		// Capture failure context BEFORE any status modification (abandon/promote).
@@ -324,12 +330,12 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 			}
 		}
 
-		// Only the first (most recent) non-terminal slip needs status update.
+		// Only the most recent same-branch non-terminal slip needs a status update.
 		// Failed slips are non-terminal and eligible for abandonment here because
 		// a new push indicates the developer has moved on. If they wanted to retry
 		// the same commit, they would re-run without pushing and the non-terminal
 		// slip would be found by ancestry resolution.
-		if i == 0 && !slip.Status.IsTerminal() {
+		if !handledAncestor && !slip.Status.IsTerminal() {
 			switch {
 			case isSquashMerge:
 				// Squash merge: promote the feature branch slip (successful outcome).
@@ -356,6 +362,7 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 					// Update the local copy to reflect the promotion
 					slip.Status = SlipStatusPromoted
 				}
+				handledAncestor = true
 
 			case opts.Branch != "" && slip.Branch != "" && slip.Branch != opts.Branch:
 				// Cross-branch ancestor found via shared git history (e.g. a push to
@@ -363,6 +370,8 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 				// "integration"). Only skip abandonment when both branch values are
 				// known and different; otherwise preserve existing abandonment
 				// behavior for slips with missing branch metadata.
+				// Do NOT set handledAncestor — keep looking for the first
+				// same-branch non-terminal slip further in the list.
 				c.logger.Info(ctx, "Skipping cross-branch ancestor slip (different branch)", map[string]interface{}{
 					"ancestor_id":        slip.CorrelationID,
 					"ancestor_branch":    slip.Branch,
@@ -394,6 +403,7 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 					// Update the local copy to reflect the abandonment
 					slip.Status = SlipStatusAbandoned
 				}
+				handledAncestor = true
 			}
 		}
 

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -338,11 +338,14 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 			}
 		}
 
-		// Only the most recent same-branch non-terminal slip needs a status update.
-		// Failed slips are non-terminal and eligible for abandonment here because
-		// a new push indicates the developer has moved on. If they wanted to retry
-		// the same commit, they would re-run without pushing and the non-terminal
-		// slip would be found by ancestry resolution.
+		// Only the most recent non-terminal ancestor slip needs a status update.
+		// Cross-branch skipping applies only when both branch values are known and
+		// different; if either branch is empty, we intentionally fall through to
+		// abandonment for backward compatibility with older slips that lack branch
+		// metadata. Failed slips are non-terminal and eligible for abandonment here
+		// because a new push indicates the developer has moved on. If they wanted
+		// to retry the same commit, they would re-run without pushing and the
+		// non-terminal slip would be found by ancestry resolution.
 		if !handledAncestor && !slip.Status.IsTerminal() {
 			switch {
 			case isSquashMerge:

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -331,7 +331,9 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 		// slip would be found by ancestry resolution.
 		if i == 0 && !slip.Status.IsTerminal() {
 			if isSquashMerge {
-				// Squash merge: promote the feature branch slip (successful outcome)
+				// Squash merge: promote the feature branch slip (successful outcome).
+				// Cross-branch promotion is expected here — the ancestor is on the
+				// feature branch being merged into the current branch.
 				c.logger.Info(ctx, "Promoting feature branch slip via squash merge", map[string]interface{}{
 					"promoted_id":     slip.CorrelationID,
 					"promoted_commit": shortSHA(slip.CommitSHA),
@@ -353,8 +355,22 @@ func (c *Client) resolveAndAbandonAncestors(ctx context.Context, opts PushOption
 					// Update the local copy to reflect the promotion
 					slip.Status = SlipStatusPromoted
 				}
+			} else if slip.Branch != opts.Branch {
+				// Cross-branch ancestor found via shared git history (e.g. a push to
+				// "main" whose ancestry walks through commits that also exist on
+				// "integration"). Do NOT abandon the slip — it belongs to a different
+				// branch and is still actively in-flight there. Record it in the
+				// ancestry chain for history but leave its status untouched.
+				c.logger.Info(ctx, "Skipping cross-branch ancestor slip (different branch)", map[string]interface{}{
+					"ancestor_id":      slip.CorrelationID,
+					"ancestor_branch":  slip.Branch,
+					"ancestor_commit":  shortSHA(slip.CommitSHA),
+					"ancestor_status":  string(slip.Status),
+					"current_branch":   opts.Branch,
+					"superseding_commit": shortSHA(opts.CommitSHA),
+				})
 			} else {
-				// Regular push: abandon superseded slip
+				// Regular push on the same branch: abandon the superseded slip.
 				c.logger.Info(ctx, "Abandoning superseded slip", map[string]interface{}{
 					"superseded_id":      slip.CorrelationID,
 					"superseded_commit":  shortSHA(slip.CommitSHA),

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -824,6 +824,189 @@ func TestClient_resolveAndAbandonAncestors(t *testing.T) {
 			t.Fatal("expected warning from store")
 		}
 	})
+
+	t.Run("does not abandon ancestor slip on a different branch", func(t *testing.T) {
+		// Regression: a push to branch "main" whose git ancestry walks through
+		// commits shared with "integration" must NOT abandon the "integration" slip.
+		// The "integration" slip is still in-flight on its own branch.
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{
+			AncestryDepth:    25,
+			AncestryMaxDepth: 100,
+		})
+
+		now := time.Now()
+		integrationSlip := &Slip{
+			CorrelationID: "corr-integration-1",
+			Repository:    "owner/repo",
+			Branch:        "integration", // different branch from the push below
+			CommitSHA:     "shared-commit-abc",
+			CreatedAt:     now.Add(-5 * time.Minute),
+			UpdatedAt:     now.Add(-5 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		store.AddSlip(integrationSlip)
+
+		// Push is to "main"; its ancestry includes "shared-commit-abc" from integration
+		github.SetAncestry("owner", "repo", "main-commit-xyz", []string{"main-commit-xyz", "shared-commit-abc"})
+
+		opts := PushOptions{
+			CorrelationID: "corr-main-1",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "main-commit-xyz",
+		}
+
+		ancestry, warnings := client.resolveAndAbandonAncestors(ctx, opts)
+		if len(warnings) > 0 {
+			t.Fatalf("unexpected warnings: %v", warnings)
+		}
+
+		// The integration slip should appear in ancestry but must NOT be abandoned
+		if len(ancestry) != 1 {
+			t.Fatalf("expected 1 ancestry entry, got %d", len(ancestry))
+		}
+		if ancestry[0].CorrelationID != "corr-integration-1" {
+			t.Errorf("expected ancestry entry 'corr-integration-1', got '%s'", ancestry[0].CorrelationID)
+		}
+
+		// No Update calls — integration slip must remain in_progress
+		if len(store.UpdateCalls) != 0 {
+			t.Errorf("expected 0 Update calls (cross-branch slip must not be touched), got %d: %v",
+				len(store.UpdateCalls), store.UpdateCalls)
+		}
+
+		// The integration slip is still in_progress in the store
+		loaded, err := store.Load(ctx, "corr-integration-1")
+		if err != nil {
+			t.Fatalf("failed to load integration slip: %v", err)
+		}
+		if loaded.Status != SlipStatusInProgress {
+			t.Errorf("integration slip status = %q, want %q", loaded.Status, SlipStatusInProgress)
+		}
+	})
+
+	t.Run("abandons ancestor slip only when on the same branch", func(t *testing.T) {
+		// Sanity check: a second push to "integration" SHOULD still abandon the
+		// previous "integration" slip (same-branch behaviour is unchanged).
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{
+			AncestryDepth:    25,
+			AncestryMaxDepth: 100,
+		})
+
+		now := time.Now()
+		prevIntegrationSlip := &Slip{
+			CorrelationID: "corr-integration-old",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "old-commit-abc",
+			CreatedAt:     now.Add(-10 * time.Minute),
+			UpdatedAt:     now.Add(-10 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		store.AddSlip(prevIntegrationSlip)
+
+		// New push is also to "integration"
+		github.SetAncestry("owner", "repo", "new-commit-xyz", []string{"new-commit-xyz", "old-commit-abc"})
+
+		opts := PushOptions{
+			CorrelationID: "corr-integration-new",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "new-commit-xyz",
+		}
+
+		ancestry, warnings := client.resolveAndAbandonAncestors(ctx, opts)
+		if len(warnings) > 0 {
+			t.Fatalf("unexpected warnings: %v", warnings)
+		}
+
+		if len(ancestry) != 1 {
+			t.Fatalf("expected 1 ancestry entry, got %d", len(ancestry))
+		}
+
+		// Same-branch slip MUST be abandoned
+		if len(store.UpdateCalls) != 1 {
+			t.Fatalf("expected 1 Update call (same-branch abandon), got %d", len(store.UpdateCalls))
+		}
+		if store.UpdateCalls[0].Slip.Status != SlipStatusAbandoned {
+			t.Errorf("expected SlipStatusAbandoned, got %q", store.UpdateCalls[0].Slip.Status)
+		}
+	})
+
+	t.Run("cross-branch does not abandon, same-branch does, when both exist in ancestry", func(t *testing.T) {
+		// Edge case: ancestry contains two slips — one from "integration" (cross-branch)
+		// and one from "main" itself (same-branch). Only the "main" slip should be abandoned.
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{
+			AncestryDepth:    25,
+			AncestryMaxDepth: 100,
+		})
+
+		now := time.Now()
+		mainOldSlip := &Slip{
+			CorrelationID: "corr-main-old",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "main-old-commit",
+			CreatedAt:     now.Add(-3 * time.Minute),
+			UpdatedAt:     now.Add(-3 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		integrationSlip := &Slip{
+			CorrelationID: "corr-integration-1",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "shared-commit-abc",
+			CreatedAt:     now.Add(-8 * time.Minute),
+			UpdatedAt:     now.Add(-8 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		store.AddSlip(mainOldSlip)
+		store.AddSlip(integrationSlip)
+
+		// main-old-commit is most recent ancestor on main; shared-commit-abc is older/cross-branch
+		github.SetAncestry("owner", "repo", "main-new-commit", []string{
+			"main-new-commit", "main-old-commit", "shared-commit-abc",
+		})
+
+		opts := PushOptions{
+			CorrelationID: "corr-main-new",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "main-new-commit",
+		}
+
+		_, warnings := client.resolveAndAbandonAncestors(ctx, opts)
+		if len(warnings) > 0 {
+			t.Fatalf("unexpected warnings: %v", warnings)
+		}
+
+		// Only the same-branch (main) slip should have been abandoned (i==0)
+		if len(store.UpdateCalls) != 1 {
+			t.Fatalf("expected exactly 1 Update call (main-old-slip), got %d", len(store.UpdateCalls))
+		}
+		if store.UpdateCalls[0].Slip.CorrelationID != "corr-main-old" {
+			t.Errorf("expected 'corr-main-old' to be abandoned, got '%s'", store.UpdateCalls[0].Slip.CorrelationID)
+		}
+
+		// Integration slip must remain untouched
+		loaded, err := store.Load(ctx, "corr-integration-1")
+		if err != nil {
+			t.Fatalf("failed to load integration slip: %v", err)
+		}
+		if loaded.Status != SlipStatusInProgress {
+			t.Errorf("integration slip = %q, want %q", loaded.Status, SlipStatusInProgress)
+		}
+	})
 }
 
 func TestClient_findAncestorSlipsWithProgressiveDepth(t *testing.T) {

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -1007,6 +1007,82 @@ func TestClient_resolveAndAbandonAncestors(t *testing.T) {
 			t.Errorf("integration slip = %q, want %q", loaded.Status, SlipStatusInProgress)
 		}
 	})
+
+	t.Run("abandons same-branch slip even when cross-branch slip sorts first in ancestry", func(t *testing.T) {
+		// Regression for the i==0 ordering bug:
+		// FindAllByCommits returns slips in commit-list order. If a cross-branch
+		// slip sits at a more recent commit position (index 0) than the same-branch
+		// slip (index 1), the same-branch slip must still be abandoned.
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{
+			AncestryDepth:    25,
+			AncestryMaxDepth: 100,
+		})
+
+		now := time.Now()
+		// Cross-branch slip at a NEWER shared commit (will be returned first by FindAllByCommits)
+		crossBranchSlip := &Slip{
+			CorrelationID: "corr-integration-newer",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "shared-newer-commit", // nearer to HEAD in ancestry list
+			CreatedAt:     now.Add(-2 * time.Minute),
+			UpdatedAt:     now.Add(-2 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		// Same-branch slip at an OLDER commit (will be returned second)
+		sameBranchSlip := &Slip{
+			CorrelationID: "corr-main-older",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "main-older-commit",
+			CreatedAt:     now.Add(-10 * time.Minute),
+			UpdatedAt:     now.Add(-10 * time.Minute),
+			Status:        SlipStatusInProgress,
+			Steps:         make(map[string]Step),
+		}
+		store.AddSlip(crossBranchSlip)
+		store.AddSlip(sameBranchSlip)
+
+		// Ancestry: newer shared commit comes before the older main commit
+		github.SetAncestry("owner", "repo", "main-new-commit", []string{
+			"main-new-commit", "shared-newer-commit", "main-older-commit",
+		})
+
+		opts := PushOptions{
+			CorrelationID: "corr-main-new",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "main-new-commit",
+		}
+
+		_, warnings := client.resolveAndAbandonAncestors(ctx, opts)
+		if len(warnings) > 0 {
+			t.Fatalf("unexpected warnings: %v", warnings)
+		}
+
+		// Exactly one Update call — the same-branch slip must be abandoned
+		if len(store.UpdateCalls) != 1 {
+			t.Fatalf("expected 1 Update call (same-branch abandon), got %d", len(store.UpdateCalls))
+		}
+		if store.UpdateCalls[0].Slip.CorrelationID != "corr-main-older" {
+			t.Errorf("expected 'corr-main-older' to be abandoned, got '%s'", store.UpdateCalls[0].Slip.CorrelationID)
+		}
+		if store.UpdateCalls[0].Slip.Status != SlipStatusAbandoned {
+			t.Errorf("expected SlipStatusAbandoned, got %q", store.UpdateCalls[0].Slip.Status)
+		}
+
+		// Cross-branch slip must remain untouched
+		loaded, err := store.Load(ctx, "corr-integration-newer")
+		if err != nil {
+			t.Fatalf("failed to load integration slip: %v", err)
+		}
+		if loaded.Status != SlipStatusInProgress {
+			t.Errorf("integration slip status = %q, want %q", loaded.Status, SlipStatusInProgress)
+		}
+	})
 }
 
 func TestClient_findAncestorSlipsWithProgressiveDepth(t *testing.T) {

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -1049,7 +1049,7 @@ func TestClient_resolveAndAbandonAncestors(t *testing.T) {
 			t.Fatalf("unexpected warnings: %v", warnings)
 		}
 
-		// Only the same-branch (main) slip should have been abandoned (i==0)
+		// Only the same-branch (main) slip should have been abandoned.
 		if len(store.UpdateCalls) != 1 {
 			t.Fatalf("expected exactly 1 Update call (main-old-slip), got %d", len(store.UpdateCalls))
 		}


### PR DESCRIPTION
## Problem

When `resolveAndAbandonAncestors` walks git history for a push to branch **X**, `FindAllByCommits` returns every slip in the repo whose commit SHA appears in that ancestry — **regardless of which branch the slip belongs to**.

This caused slips on long-running branches (e.g. `integration`) to be silently abandoned whenever a push to another branch (e.g. `main`) happened to share commits in its git ancestry.

### Concrete failure scenario (MC.CarrierIntegrations)

1. Push to `integration` → slip `d9688adf` created (`in_progress`)
2. Builds complete, dev deploy partially fails — slip still `in_progress`
3. A push to **another branch** (`main` or a feature branch) whose `git log` ancestry includes the same commits as `integration`
4. pushhookparser calls `CreateSlipForPush` for that other branch
5. `resolveAndAbandonAncestors` → `FindAllByCommits` finds `d9688adf` (different branch, shared commit)
6. `i == 0`, not terminal → **ABANDONED** ❌
7. In-flight Argo workflows on `integration` continue writing steps to `d9688adf`, but ClickHouse shows `abandoned`

## Fix

Before abandoning the most-recent non-terminal ancestor, check that `slip.Branch == opts.Branch` (same-branch push). Cross-branch ancestors are still recorded in the ancestry chain for history and reporting, but their status is left untouched.

The **squash-merge promotion path** is unchanged — it's triggered only via PR-based lookup (`findAncestorViaSquashMerge`) and explicitly expects a cross-branch ancestor.

```
Push to "main"
  └── resolveAndAbandonAncestors
        └── FindAllByCommits → [slip on "integration" (shared commit)]
              └── slip.Branch ("integration") != opts.Branch ("main")
                    → SKIP abandonment, record in ancestry only  ✅
```

## Tests

Three new regression tests in `TestClient_resolveAndAbandonAncestors`:

| Test | Verifies |
|------|----------|
| `does not abandon ancestor slip on a different branch` | Cross-branch slip stays `in_progress` |
| `abandons ancestor slip only when on the same branch` | Same-branch behaviour unchanged |
| `cross-branch does not abandon, same-branch does, when both exist in ancestry` | Mixed ancestry: only same-branch slip abandoned |

All existing tests pass.

## Impact

- **pushhookparser**: no code change needed — the fix is in the library it calls
- **Slippy CLI**: no change needed  
- **Backward compatible**: same-branch abandonment is unchanged; squash-merge promotion is unchanged