### PR TITLE
fix(slippy): update step-status column atomically for pure pipeline steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - main
       - 'feature/**'
       - 'hotfix/**'
+      - 'fix/**'
   pull_request:
     paths:
       - '**'
@@ -172,6 +173,7 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' ||
       startsWith(github.ref, 'refs/heads/feature/') ||
+      startsWith(github.ref, 'refs/heads/fix/') ||
       startsWith(github.ref, 'refs/heads/hotfix/')
     outputs:
       version: ${{ steps.release_version.outputs.version }}

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -1051,21 +1051,29 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 	// updated atomically alongside the history entry. This fixes the case where a pure
 	// pipeline step (e.g. unit_tests) would otherwise copy a stale "running" value from
 	// the routing_slips row that was last written by the builds aggregate write-back.
-	overrideByCol := make(map[string]StepStatus, len(overrides))
-	for _, o := range overrides {
-		overrideByCol[o.columnName] = o.status
-	}
-	stepSelectExprs := make([]string, 0, len(stepColumns))
-	stepOverrideArgs := make([]interface{}, 0, len(overrides))
-	for _, col := range stepColumns {
-		if overrideStatus, ok := overrideByCol[col]; ok {
-			stepSelectExprs = append(stepSelectExprs, "?")
-			stepOverrideArgs = append(stepOverrideArgs, string(overrideStatus))
-		} else {
+	//
+	// Fast-path: AppendHistory always calls with zero overrides, so skip the map/slice
+	// allocations entirely in that common case.
+	var stepOverrideArgs []interface{}
+	if len(overrides) == 0 {
+		newRowSelectCols = append(newRowSelectCols, stepColumns...)
+	} else {
+		overrideByCol := make(map[string]StepStatus, len(overrides))
+		for _, o := range overrides {
+			overrideByCol[o.columnName] = o.status
+		}
+		stepSelectExprs := make([]string, 0, len(stepColumns))
+		stepOverrideArgs = make([]interface{}, 0, len(overrides))
+		for _, col := range stepColumns {
+			if overrideStatus, ok := overrideByCol[col]; ok {
+				stepSelectExprs = append(stepSelectExprs, "?")
+				stepOverrideArgs = append(stepOverrideArgs, string(overrideStatus))
+				continue
+			}
 			stepSelectExprs = append(stepSelectExprs, col)
 		}
+		newRowSelectCols = append(newRowSelectCols, stepSelectExprs...)
 	}
-	newRowSelectCols = append(newRowSelectCols, stepSelectExprs...)
 	newRowSelectCols = append(newRowSelectCols, aggregateColumns...)
 
 	newRowQuery := fmt.Sprintf(

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -535,137 +535,6 @@ func (s *ClickHouseStore) AppendHistory(ctx context.Context, correlationID strin
 	return s.appendHistoryWithOverrides(ctx, correlationID, entry)
 }
 
-// appendHistoryWithOverrides is the internal implementation of AppendHistory.
-// When overrides are provided, the named step-status columns are written with the
-// supplied literal values instead of being copied verbatim from the DB row.
-// This is used by UpdateStepWithHistory to atomically persist both the history
-// entry and the step-status column for pure pipeline steps (non-aggregate,
-// componentName == ""), closing the gap where insertAtomicHistoryUpdate would
-// otherwise copy a stale "running" value from the DB.
-func (s *ClickHouseStore) appendHistoryWithOverrides(
-	ctx context.Context,
-	correlationID string,
-	entry StateHistoryEntry,
-	overrides ...stepStatusOverride,
-) error {
-	// Start tracing span for the retry operation
-	retrySpan := startRetrySpan(ctx, "AppendHistory", correlationID)
-	retrySpan.AddAttribute("slippy.entry_step", entry.Step)
-	retrySpan.AddAttribute("slippy.entry_status", string(entry.Status))
-
-	slipNotFoundRetry := 0    // Counter for slip-not-found retries (1-indexed when used)
-	historyConflictRetry := 0 // Counter for concurrent-writer conflict retries
-
-	// Retry loop handles slip-not-found scenarios and post-write history-conflict retries.
-	for {
-		// Check for context cancellation first
-		if ctx.Err() != nil {
-			retrySpan.EndError(ctx.Err())
-			return ctx.Err()
-		}
-
-		// Load only state_history to avoid a full hydrateSlip round-trip.
-		// This keeps step-status columns in the re-inserted row aligned with the
-		// current DB row rather than an in-memory view that might be stale.
-		existingHistoryJSON, err := s.loadStateHistoryFromDB(retrySpan.Context(), correlationID)
-		if err != nil {
-			if errors.Is(err, ErrSlipNotFound) {
-				slipNotFoundRetry++
-				if slipNotFoundRetry > slipNotFoundMaxRetries {
-					err := fmt.Errorf("%w: slip not found after %d retries: %w",
-						ErrMaxRetriesExceeded, slipNotFoundMaxRetries, ErrSlipNotFound)
-					retrySpan.EndError(err)
-					return err
-				}
-
-				backoff := calculateSlipNotFoundBackoff(slipNotFoundRetry)
-				retrySpan.RecordAttempt(backoff.Milliseconds())
-				retrySpan.AddAttribute("slippy.waiting_for_slip_creation", true)
-				retrySpan.AddAttribute("slippy.slip_not_found_retry", slipNotFoundRetry)
-				select {
-				case <-ctx.Done():
-					retrySpan.EndError(ctx.Err())
-					return ctx.Err()
-				case <-time.After(backoff):
-				}
-				continue
-			}
-			retrySpan.EndError(err)
-			return err
-		}
-
-		// Deserialize existing history, append the new entry, re-serialize.
-		var wrapper struct {
-			Entries []StateHistoryEntry `json:"entries"`
-		}
-		if err := json.Unmarshal([]byte(existingHistoryJSON), &wrapper); err != nil {
-			// History JSON is malformed. Returning an error here avoids silently
-			// discarding existing history. The caller's retry loop can surface this
-			// to the operator rather than overwriting potentially valid data.
-			parseErr := fmt.Errorf("state_history JSON is malformed for %s: %w", correlationID, err)
-			retrySpan.AddAttribute("slippy.history_unmarshal_error", parseErr.Error())
-			retrySpan.EndError(parseErr)
-			return parseErr
-		}
-		wrapper.Entries = append(wrapper.Entries, entry)
-		newHistoryJSON, err := json.Marshal(wrapper)
-		if err != nil {
-			retrySpan.EndError(err)
-			return fmt.Errorf("failed to marshal updated state history: %w", err)
-		}
-
-		// Load current DB version so we can guarantee newVersion > existing version,
-		// preventing invisible updates when another writer used a skewed clock.
-		currentVersion, versionLoadErr := s.loadVersionFromDB(retrySpan.Context(), correlationID)
-		if versionLoadErr != nil {
-			// Non-fatal: fall back to nextVersion() with no floor guarantee.
-			// Post-write version check will still catch conflicts.
-			currentVersion = 0
-		}
-		newVersion := s.nextVersion()
-		if newVersion <= currentVersion {
-			newVersion = currentVersion + 1
-		}
-		if err := s.insertAtomicHistoryUpdate(
-			retrySpan.Context(), correlationID, newVersion, string(newHistoryJSON), overrides...,
-		); err != nil {
-			retrySpan.EndError(err)
-			return err
-		}
-
-		// Post-write version check: if a concurrent writer inserted a higher-version
-		// routing_slips row after our loadStateHistoryFromDB read, that row wins the
-		// last-write-wins merge and our appended entry is dropped. Detect and retry.
-		latestVersion, versionErr := s.loadVersionFromDB(retrySpan.Context(), correlationID)
-		if versionErr != nil {
-			// Non-fatal: accept potential history loss if the version check fails.
-			retrySpan.AddAttribute("slippy.history_version_check_error", versionErr.Error())
-			retrySpan.EndSuccess()
-			return nil
-		}
-		if latestVersion > newVersion {
-			historyConflictRetry++
-			retrySpan.AddAttribute("slippy.history_conflict_retry", historyConflictRetry)
-			if historyConflictRetry > historyConflictMaxRetries {
-				retrySpan.AddAttribute("slippy.history_conflict_retries_exhausted", true)
-				retrySpan.EndSuccess()
-				return nil
-			}
-			backoff := calculateAggregateConflictBackoff(historyConflictRetry)
-			select {
-			case <-ctx.Done():
-				retrySpan.EndError(ctx.Err())
-				return ctx.Err()
-			case <-time.After(backoff):
-			}
-			continue
-		}
-
-		retrySpan.EndSuccess()
-		return nil
-	}
-}
-
 // Close releases any resources held by the store.
 func (s *ClickHouseStore) Close() error {
 	return s.session.Close()
@@ -813,6 +682,137 @@ func (s *ClickHouseStore) SetComponentImageTag(
 
 	return s.insertComponentState(ctx, correlationID, stepName, componentName,
 		StepStatus(currentStatus), "", imageTag)
+}
+
+// appendHistoryWithOverrides is the internal implementation of AppendHistory.
+// When overrides are provided, the named step-status columns are written with the
+// supplied literal values instead of being copied verbatim from the DB row.
+// This is used by UpdateStepWithHistory to atomically persist both the history
+// entry and the step-status column for pure pipeline steps (non-aggregate,
+// componentName == ""), closing the gap where insertAtomicHistoryUpdate would
+// otherwise copy a stale "running" value from the DB.
+func (s *ClickHouseStore) appendHistoryWithOverrides(
+	ctx context.Context,
+	correlationID string,
+	entry StateHistoryEntry,
+	overrides ...stepStatusOverride,
+) error {
+	// Start tracing span for the retry operation
+	retrySpan := startRetrySpan(ctx, "AppendHistory", correlationID)
+	retrySpan.AddAttribute("slippy.entry_step", entry.Step)
+	retrySpan.AddAttribute("slippy.entry_status", string(entry.Status))
+
+	slipNotFoundRetry := 0    // Counter for slip-not-found retries (1-indexed when used)
+	historyConflictRetry := 0 // Counter for concurrent-writer conflict retries
+
+	// Retry loop handles slip-not-found scenarios and post-write history-conflict retries.
+	for {
+		// Check for context cancellation first
+		if ctx.Err() != nil {
+			retrySpan.EndError(ctx.Err())
+			return ctx.Err()
+		}
+
+		// Load only state_history to avoid a full hydrateSlip round-trip.
+		// This keeps step-status columns in the re-inserted row aligned with the
+		// current DB row rather than an in-memory view that might be stale.
+		existingHistoryJSON, err := s.loadStateHistoryFromDB(retrySpan.Context(), correlationID)
+		if err != nil {
+			if errors.Is(err, ErrSlipNotFound) {
+				slipNotFoundRetry++
+				if slipNotFoundRetry > slipNotFoundMaxRetries {
+					err := fmt.Errorf("%w: slip not found after %d retries: %w",
+						ErrMaxRetriesExceeded, slipNotFoundMaxRetries, ErrSlipNotFound)
+					retrySpan.EndError(err)
+					return err
+				}
+
+				backoff := calculateSlipNotFoundBackoff(slipNotFoundRetry)
+				retrySpan.RecordAttempt(backoff.Milliseconds())
+				retrySpan.AddAttribute("slippy.waiting_for_slip_creation", true)
+				retrySpan.AddAttribute("slippy.slip_not_found_retry", slipNotFoundRetry)
+				select {
+				case <-ctx.Done():
+					retrySpan.EndError(ctx.Err())
+					return ctx.Err()
+				case <-time.After(backoff):
+				}
+				continue
+			}
+			retrySpan.EndError(err)
+			return err
+		}
+
+		// Deserialize existing history, append the new entry, re-serialize.
+		var wrapper struct {
+			Entries []StateHistoryEntry `json:"entries"`
+		}
+		if err := json.Unmarshal([]byte(existingHistoryJSON), &wrapper); err != nil {
+			// History JSON is malformed. Returning an error here avoids silently
+			// discarding existing history. The caller's retry loop can surface this
+			// to the operator rather than overwriting potentially valid data.
+			parseErr := fmt.Errorf("state_history JSON is malformed for %s: %w", correlationID, err)
+			retrySpan.AddAttribute("slippy.history_unmarshal_error", parseErr.Error())
+			retrySpan.EndError(parseErr)
+			return parseErr
+		}
+		wrapper.Entries = append(wrapper.Entries, entry)
+		newHistoryJSON, err := json.Marshal(wrapper)
+		if err != nil {
+			retrySpan.EndError(err)
+			return fmt.Errorf("failed to marshal updated state history: %w", err)
+		}
+
+		// Load current DB version so we can guarantee newVersion > existing version,
+		// preventing invisible updates when another writer used a skewed clock.
+		currentVersion, versionLoadErr := s.loadVersionFromDB(retrySpan.Context(), correlationID)
+		if versionLoadErr != nil {
+			// Non-fatal: fall back to nextVersion() with no floor guarantee.
+			// Post-write version check will still catch conflicts.
+			currentVersion = 0
+		}
+		newVersion := s.nextVersion()
+		if newVersion <= currentVersion {
+			newVersion = currentVersion + 1
+		}
+		if err := s.insertAtomicHistoryUpdate(
+			retrySpan.Context(), correlationID, newVersion, string(newHistoryJSON), overrides...,
+		); err != nil {
+			retrySpan.EndError(err)
+			return err
+		}
+
+		// Post-write version check: if a concurrent writer inserted a higher-version
+		// routing_slips row after our loadStateHistoryFromDB read, that row wins the
+		// last-write-wins merge and our appended entry is dropped. Detect and retry.
+		latestVersion, versionErr := s.loadVersionFromDB(retrySpan.Context(), correlationID)
+		if versionErr != nil {
+			// Non-fatal: accept potential history loss if the version check fails.
+			retrySpan.AddAttribute("slippy.history_version_check_error", versionErr.Error())
+			retrySpan.EndSuccess()
+			return nil
+		}
+		if latestVersion > newVersion {
+			historyConflictRetry++
+			retrySpan.AddAttribute("slippy.history_conflict_retry", historyConflictRetry)
+			if historyConflictRetry > historyConflictMaxRetries {
+				retrySpan.AddAttribute("slippy.history_conflict_retries_exhausted", true)
+				retrySpan.EndSuccess()
+				return nil
+			}
+			backoff := calculateAggregateConflictBackoff(historyConflictRetry)
+			select {
+			case <-ctx.Done():
+				retrySpan.EndError(ctx.Err())
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			continue
+		}
+
+		retrySpan.EndSuccess()
+		return nil
+	}
 }
 
 // nextVersion returns a nanosecond-epoch version. If the current wall clock
@@ -1089,8 +1089,7 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 	//   4. new-row step overrides in column order     (one ? per override)
 	//   5. new-row SELECT WHERE: correlationID
 	execArgs := make([]interface{}, 0, 5+len(stepOverrideArgs))
-	execArgs = append(execArgs, correlationID, newVersion)
-	execArgs = append(execArgs, newStateHistoryJSON, newVersion)
+	execArgs = append(execArgs, correlationID, newVersion, newStateHistoryJSON, newVersion)
 	execArgs = append(execArgs, stepOverrideArgs...)
 	execArgs = append(execArgs, correlationID)
 

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -508,7 +508,17 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 		return s.updateAggregateStatusFromComponentStatesWithHistory(ctx, correlationID, stepName, entry)
 	}
 
-	// Pure pipeline step: persist only the history entry to routing_slips.
+	// Pure pipeline step: persist the history entry AND update the step-status column
+	// in routing_slips atomically. Without the override, insertAtomicHistoryUpdate would
+	// copy the stale "running" value written earlier by the builds aggregate write-back
+	// (updateAggregateStatusFromComponentStatesWithHistory calls s.Update which snapshots
+	// unit_tests_status = "running" from hydrateSlip's first pass over slip_component_states).
+	// Passing the override makes the INSERT SELECT use the literal status we just wrote to
+	// slip_component_states, keeping routing_slips consistent without a Load+Update cycle.
+	if s.pipelineConfig != nil {
+		colName := s.queryBuilder.StepStatusColumn(stepName)
+		return s.appendHistoryWithOverrides(ctx, correlationID, entry, stepStatusOverride{colName, status})
+	}
 	return s.AppendHistory(ctx, correlationID, entry)
 }
 
@@ -522,6 +532,22 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 // This prevents a concurrent step-status update from being overwritten in the
 // routing_slips cache by an in-flight AppendHistory that loaded a stale snapshot.
 func (s *ClickHouseStore) AppendHistory(ctx context.Context, correlationID string, entry StateHistoryEntry) error {
+	return s.appendHistoryWithOverrides(ctx, correlationID, entry)
+}
+
+// appendHistoryWithOverrides is the internal implementation of AppendHistory.
+// When overrides are provided, the named step-status columns are written with the
+// supplied literal values instead of being copied verbatim from the DB row.
+// This is used by UpdateStepWithHistory to atomically persist both the history
+// entry and the step-status column for pure pipeline steps (non-aggregate,
+// componentName == ""), closing the gap where insertAtomicHistoryUpdate would
+// otherwise copy a stale "running" value from the DB.
+func (s *ClickHouseStore) appendHistoryWithOverrides(
+	ctx context.Context,
+	correlationID string,
+	entry StateHistoryEntry,
+	overrides ...stepStatusOverride,
+) error {
 	// Start tracing span for the retry operation
 	retrySpan := startRetrySpan(ctx, "AppendHistory", correlationID)
 	retrySpan.AddAttribute("slippy.entry_step", entry.Step)
@@ -601,7 +627,7 @@ func (s *ClickHouseStore) AppendHistory(ctx context.Context, correlationID strin
 			newVersion = currentVersion + 1
 		}
 		if err := s.insertAtomicHistoryUpdate(
-			retrySpan.Context(), correlationID, newVersion, string(newHistoryJSON),
+			retrySpan.Context(), correlationID, newVersion, string(newHistoryJSON), overrides...,
 		); err != nil {
 			retrySpan.EndError(err)
 			return err
@@ -932,6 +958,17 @@ func (s *ClickHouseStore) loadStateHistoryFromDB(ctx context.Context, correlatio
 	return string(jsonBytes), nil
 }
 
+// stepStatusOverride pairs a routing_slips step-status column name (e.g. "unit_tests_status")
+// with the literal value to write. When passed to insertAtomicHistoryUpdate the verbatim
+// DB column reference is replaced with a SQL literal so the step-status column is updated
+// atomically with the history entry. This is used by the pure-pipeline-step path in
+// UpdateStepWithHistory to persist the correct status in routing_slips without a separate
+// Load+Update round-trip.
+type stepStatusOverride struct {
+	columnName string
+	status     StepStatus
+}
+
 // insertAtomicHistoryUpdate cancels all active routing_slips rows for correlationID and inserts
 // a new row that is identical to the latest active row except for state_history, updated_at,
 // sign, and version. All step-status and aggregate columns are copied verbatim from the DB row,
@@ -941,6 +978,7 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 	correlationID string,
 	newVersion uint64,
 	newStateHistoryJSON string,
+	overrides ...stepStatusOverride,
 ) error {
 	if s.pipelineConfig == nil {
 		return fmt.Errorf("pipeline config is required for store operations")
@@ -1007,7 +1045,27 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 		newRowSelectCols = append(newRowSelectCols, ColumnAncestry) // ancestry passthrough
 	}
 	newRowSelectCols = append(newRowSelectCols, "1", "?") // sign=1, version=newVersion
-	newRowSelectCols = append(newRowSelectCols, stepColumns...)
+
+	// Build step SELECT expressions. For columns that have a stepStatusOverride, replace
+	// the verbatim DB column reference with a literal (?) so the step-status value is
+	// updated atomically alongside the history entry. This fixes the case where a pure
+	// pipeline step (e.g. unit_tests) would otherwise copy a stale "running" value from
+	// the routing_slips row that was last written by the builds aggregate write-back.
+	overrideByCol := make(map[string]StepStatus, len(overrides))
+	for _, o := range overrides {
+		overrideByCol[o.columnName] = o.status
+	}
+	stepSelectExprs := make([]string, 0, len(stepColumns))
+	stepOverrideArgs := make([]interface{}, 0, len(overrides))
+	for _, col := range stepColumns {
+		if overrideStatus, ok := overrideByCol[col]; ok {
+			stepSelectExprs = append(stepSelectExprs, "?")
+			stepOverrideArgs = append(stepOverrideArgs, string(overrideStatus))
+		} else {
+			stepSelectExprs = append(stepSelectExprs, col)
+		}
+	}
+	newRowSelectCols = append(newRowSelectCols, stepSelectExprs...)
 	newRowSelectCols = append(newRowSelectCols, aggregateColumns...)
 
 	newRowQuery := fmt.Sprintf(
@@ -1024,14 +1082,19 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 		%s
 	`, s.database, TableRoutingSlips, strings.Join(allCols, ", "), cancelQuery, newRowQuery)
 
-	err := s.session.ExecWithArgs(ctx, query,
-		// Cancel SELECT WHERE params
-		correlationID, newVersion,
-		// New row SELECT literal params (state_history, version)
-		newStateHistoryJSON, newVersion,
-		// New row SELECT WHERE param
-		correlationID,
-	)
+	// Build the args slice in SELECT parameter order:
+	//   1. cancel-row WHERE:     correlationID, newVersion
+	//   2. new-row SELECT CAST:  newStateHistoryJSON  (state_history literal)
+	//   3. new-row SELECT ?:     newVersion           (version literal)
+	//   4. new-row step overrides in column order     (one ? per override)
+	//   5. new-row SELECT WHERE: correlationID
+	execArgs := make([]interface{}, 0, 5+len(stepOverrideArgs))
+	execArgs = append(execArgs, correlationID, newVersion)
+	execArgs = append(execArgs, newStateHistoryJSON, newVersion)
+	execArgs = append(execArgs, stepOverrideArgs...)
+	execArgs = append(execArgs, correlationID)
+
+	err := s.session.ExecWithArgs(ctx, query, execArgs...)
 	if err != nil && hasAncestry && isAncestryColumnError(err) {
 		// The probe assumed ancestry exists but ClickHouse reports an unknown column —
 		// migration v10 has been applied despite the probe not seeing it (transient failure).
@@ -1041,7 +1104,7 @@ func (s *ClickHouseStore) insertAtomicHistoryUpdate(
 			"correlation_id": correlationID,
 		})
 		s.hasAncestryColumn.Store(false)
-		return s.insertAtomicHistoryUpdate(ctx, correlationID, newVersion, newStateHistoryJSON)
+		return s.insertAtomicHistoryUpdate(ctx, correlationID, newVersion, newStateHistoryJSON, overrides...)
 	}
 	return err
 }

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -3204,7 +3204,137 @@ func TestClickHouseStore_UpdateStepWithHistory_PurePipelineStep(t *testing.T) {
 	}
 }
 
-// TestClickHouseStore_SetComponentImageTag_QueryRowError verifies that when the initial
+// TestClickHouseStore_UpdateStepWithHistory_PurePipelineStep_StatusOverrideInSQL is a
+// regression test for the unit_tests_status staleness bug (introduced in v1.3.70).
+// It verifies that when UpdateStepWithHistory is called for a pure pipeline step
+// (non-aggregate, componentName == ""), insertAtomicHistoryUpdate replaces the step-status
+// column reference with a SQL literal (?) in the new-row SELECT instead of copying the
+// verbatim DB column value — and that the override status is injected into ExecWithArgs
+// args at the correct position.
+//
+// Without this fix, "running" written by the builds aggregate write-back would be copied
+// verbatim, leaving unit_tests_status (or any pure pipeline step status) permanently stale.
+func TestClickHouseStore_UpdateStepWithHistory_PurePipelineStep_StatusOverrideInSQL(t *testing.T) {
+	const corrID = "corr-status-override-regression"
+	mockSession := createMockSessionForUpdates(corrID, "myorg/myrepo", "main", "abc123", SlipStatusInProgress, 1)
+	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+	entry := StateHistoryEntry{
+		Timestamp: time.Now(),
+		Step:      "push_parsed",
+		Status:    StepStatusCompleted,
+		Actor:     "ci",
+	}
+
+	err := store.UpdateStepWithHistory(
+		context.Background(), corrID, "push_parsed", "", StepStatusCompleted, entry,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Find the routing_slips INSERT call (insertAtomicHistoryUpdate).
+	// The other ExecWithArgs call is the slip_component_states insert.
+	var historyStmt string
+	var historyArgs []any
+	for _, call := range mockSession.ExecWithArgsCalls {
+		if strings.Contains(call.Stmt, "routing_slips") {
+			historyStmt = call.Stmt
+			historyArgs = call.Args
+			break
+		}
+	}
+	if historyStmt == "" {
+		t.Fatal("expected a routing_slips INSERT (insertAtomicHistoryUpdate), found none")
+	}
+
+	// The override path must replace the step-status column reference with ? in the
+	// new-row SELECT. Without the fix, "push_parsed_status" appears 3 times in the query
+	// (INSERT column list + cancel SELECT + new-row SELECT). With the fix it appears
+	// exactly twice (INSERT column list + cancel SELECT only; new-row SELECT uses ?).
+	const colName = "push_parsed_status"
+	occurrences := strings.Count(historyStmt, colName)
+	if occurrences != 2 {
+		t.Errorf(
+			"expected %q to appear 2 times in routing_slips INSERT (column list + cancel SELECT only),"+
+				" got %d — new-row SELECT should use ? instead.\nQuery: %s",
+			colName, occurrences, historyStmt,
+		)
+	}
+
+	// Args order for insertAtomicHistoryUpdate with 1 override (push_parsed_status):
+	//   [0] correlationID          (cancel WHERE)
+	//   [1] newVersion (uint64)    (cancel WHERE)
+	//   [2] newStateHistoryJSON    (new-row CAST(? AS JSON) literal)
+	//   [3] newVersion (uint64)    (new-row version literal)
+	//   [4] "completed"            (push_parsed_status override value)  ← THE FIX
+	//   [5] correlationID          (new-row WHERE)
+	const wantArgCount = 6
+	if len(historyArgs) != wantArgCount {
+		t.Fatalf("expected %d ExecWithArgs args (5 base + 1 step override), got %d: %v",
+			wantArgCount, len(historyArgs), historyArgs)
+	}
+	overrideArg, ok := historyArgs[4].(string)
+	if !ok {
+		t.Fatalf("expected args[4] (step status override) to be string, got %T: %v",
+			historyArgs[4], historyArgs[4])
+	}
+	if overrideArg != string(StepStatusCompleted) {
+		t.Errorf("expected args[4] (step status override) = %q, got %q",
+			string(StepStatusCompleted), overrideArg)
+	}
+}
+
+// TestClickHouseStore_AppendHistory_NoStatusColumnOverride verifies the contrasting case:
+// AppendHistory (public, no overrides) must NOT inject extra step-status args and must
+// NOT replace the step-status column reference with ? — the verbatim DB column value is
+// copied as-is. This ensures the override mechanism is scoped exclusively to
+// UpdateStepWithHistory's pure-pipeline-step path and does not affect other callers.
+func TestClickHouseStore_AppendHistory_NoStatusColumnOverride(t *testing.T) {
+	const corrID = "corr-appendhistory-no-override"
+	mockSession := createMockSessionForUpdates(corrID, "myorg/myrepo", "main", "abc123", SlipStatusInProgress, 1)
+	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+	entry := StateHistoryEntry{
+		Timestamp: time.Now(),
+		Step:      "push_parsed",
+		Status:    StepStatusCompleted,
+		Actor:     "ci",
+	}
+
+	err := store.AppendHistory(context.Background(), corrID, entry)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// AppendHistory must produce exactly one ExecWithArgs call (insertAtomicHistoryUpdate).
+	if len(mockSession.ExecWithArgsCalls) != 1 {
+		t.Fatalf("expected 1 ExecWithArgs call, got %d", len(mockSession.ExecWithArgsCalls))
+	}
+	call := mockSession.ExecWithArgsCalls[0]
+
+	// Without overrides, exactly 5 base args:
+	//   [0] correlationID, [1] newVersion, [2] newStateHistoryJSON, [3] newVersion, [4] correlationID.
+	// No extra step-status arg injected.
+	const wantArgCount = 5
+	if len(call.Args) != wantArgCount {
+		t.Errorf("expected %d ExecWithArgs args (no override), got %d: %v",
+			wantArgCount, len(call.Args), call.Args)
+	}
+
+	// push_parsed_status must appear 3 times verbatim (INSERT column list + cancel SELECT +
+	// new-row SELECT), confirming the column is copied from DB and not replaced with ?.
+	const colName = "push_parsed_status"
+	occurrences := strings.Count(call.Stmt, colName)
+	if occurrences != 3 {
+		t.Errorf(
+			"expected %q to appear 3 times in routing_slips INSERT (column list + cancel + new-row SELECT), got %d.\nQuery: %s",
+			colName, occurrences, call.Stmt,
+		)
+	}
+}
+
+
 // status read (QueryRow) returns an error, SetComponentImageTag propagates it and does
 // not attempt an insert.
 func TestClickHouseStore_SetComponentImageTag_QueryRowError(t *testing.T) {

--- a/slippy/default.json
+++ b/slippy/default.json
@@ -73,12 +73,12 @@
     {
       "name": "prod_rollback",
       "description": "Automated GitOps + source repo rollback triggered when prod_alert_gate fails",
-      "prerequisites": ["prod_deploy"]
+      "prerequisites": ["prod_deploy", "prod_tests"]
     },
     {
       "name": "prod_steady_state",
       "description": "Pipeline terminal marker — all post-deploy steps finished",
-      "prerequisites": ["prod_deploy"]
+      "prerequisites": ["prod_deploy", "prod_tests"]
     }
   ]
 }

--- a/slippy/default.json
+++ b/slippy/default.json
@@ -73,12 +73,12 @@
     {
       "name": "prod_rollback",
       "description": "Automated GitOps + source repo rollback triggered when prod_alert_gate fails",
-      "prerequisites": ["prod_alert_gate"]
+      "prerequisites": ["prod_deploy"]
     },
     {
       "name": "prod_steady_state",
       "description": "Pipeline terminal marker — all post-deploy steps finished",
-      "prerequisites": ["prod_alert_gate", "prod_rollback"]
+      "prerequisites": ["prod_deploy"]
     }
   ]
 }

--- a/slippy/default.json
+++ b/slippy/default.json
@@ -64,6 +64,21 @@
       "name": "prod_tests",
       "description": "Smoke tests in production environment",
       "prerequisites": ["prod_gate", "prod_deploy"]
+    },
+    {
+      "name": "prod_alert_gate",
+      "description": "Post-deploy alert monitoring — watches for degradation signals after production deploy",
+      "prerequisites": ["prod_deploy", "prod_tests"]
+    },
+    {
+      "name": "prod_rollback",
+      "description": "Automated GitOps + source repo rollback triggered when prod_alert_gate fails",
+      "prerequisites": ["prod_alert_gate"]
+    },
+    {
+      "name": "prod_steady_state",
+      "description": "Pipeline terminal marker — all post-deploy steps finished",
+      "prerequisites": ["prod_alert_gate", "prod_rollback"]
     }
   ]
 }


### PR DESCRIPTION
## Problem

Three routing slip records were stuck in `status: in_progress` indefinitely. All three shared the same symptom:

- `unit_tests_status = "running"` in the `routing_slips` ClickHouse table
- `state_history` contained a `"step completed successfully"` entry for `unit_tests`
- Because `dev_deploy.prerequisites` includes `unit_tests`, any downstream step waiting on prereqs correctly advanced (runtime prereq check reads from `slip_component_states` via `hydrateSlip`), but the **overall slip status stayed `in_progress`** because the routing_slips cache column was permanently stale

Affected slips:
- `be202550-e778-454a-8afa-7b58c292b919` — MC.Invoice / AQAupdate
- `9ae46aba-…` — MC.Invoice / SkipUserInfoLoad
- `7f1022c8-…` — MC.Shipment / 80398-shipment-notification-emails

---

## Root Cause

### How `unit_tests_status = "running"` gets written correctly…

When the last `builds` component finishes, `UpdateStepWithHistory` takes **Path A** (aggregate step) → `updateAggregateStatusFromComponentStatesWithHistory` → `s.Load()` → `hydrateSlip`:

1. `hydrateSlip` queries `slip_component_states` for every step. For `unit_tests` it finds the pre-job event `("unit_tests", "", "running")` (most recent by `argMax(status, timestamp)`) → sets `unit_tests.Status = "running"` in memory.
2. `s.Update(slip)` writes **all** step columns including `unit_tests_status = "running"` to `routing_slips`.

This is correct — the unit test job was still running at that point.

### …but never gets updated to `"completed"`

`SendUnitTesterEvent` in `pushhookparser/pkg/kafka/events.go` hardcodes `"path": ""`:

```go
// pushhookparser/pkg/kafka/events.go
err = kafkaClient.Produce(ctx, topicName, UnitTesterEvent{
    ...
    "path": "",   // ← hardcoded empty string
})
```

This flows through Argo's `unit-test.yaml`:
```
component_name = sprig.lower(sprig.last(sprig.splitList('/', ""))) = ""
```

So the CLI post-job call is:
```
slippy post-job --step unit_tests --success   # no --component flag
```

`UpdateStepWithHistory(id, "unit_tests", "", completed, entry)` therefore always takes **Path B** (pure pipeline step — `componentName == ""` AND `!IsAggregateStep("unit_tests")`).

**Path B before this fix** called `AppendHistory` → `insertAtomicHistoryUpdate`, which cancels all active routing_slips rows and inserts a new row by copying **all columns verbatim** from the latest DB row. The `unit_tests_status` column was never updated — it stayed `"running"` forever.

### Why the pipeline advanced despite the stale column

`WaitForPrerequisites` → `store.Load()` → `hydrateSlip` → `doLoadComponentStates` → `argMax(status, timestamp)` over `slip_component_states` → returns `"completed"` (the post-job event is the most recent). The in-memory prereq check passes fine. The bug was **purely a routing_slips cache staleness issue**.

### When was the bug introduced?

Commit `fix(slippy): eliminate pipeline-step concurrent lost-update via event sourcing` (v1.3.70) redesigned pure pipeline steps to use `AppendHistory` (event-sourcing, no Load+Update round-trip) to eliminate lost-update races. The redesign fixed the race but accidentally removed the `unit_tests_status` column update for the pure-pipeline-step path.

---

## Fix

### Approach: atomic status column override (Option 2 — Consistent)

Rather than doing a separate Load+Update (which reintroduces the race) or changing the `SlipStore` interface (which would require updating mock and all callers), we thread a variadic `stepStatusOverride` down the private call chain so `insertAtomicHistoryUpdate` can replace specific verbatim column references with SQL literal `?` placeholders.

### Changes to `slippy/clickhouse_store.go`

**1. New private type**
```go
type stepStatusOverride struct {
    columnName string   // e.g. "unit_tests_status"
    status     StepStatus
}
```

**2. `AppendHistory` → thin wrapper**  
Public interface signature is unchanged. Body delegates to new `appendHistoryWithOverrides` with no overrides.

**3. New `appendHistoryWithOverrides`**  
Contains the existing retry loop; accepts variadic `overrides ...stepStatusOverride`; passes them to `insertAtomicHistoryUpdate`.

**4. `insertAtomicHistoryUpdate` — override-aware step column SELECT**  
For each column in `stepColumns`, if an override exists the verbatim column reference is replaced with `?` and the literal value is appended to `execArgs` (between the `version` literal and the `WHERE` correlationID param, preserving ClickHouse parameter order).

**5. `UpdateStepWithHistory` Path B — inject the override**
```go
// Before
return s.AppendHistory(ctx, correlationID, entry)

// After
if s.pipelineConfig != nil {
    colName := s.queryBuilder.StepStatusColumn(stepName)
    return s.appendHistoryWithOverrides(ctx, correlationID, entry,
        stepStatusOverride{colName, status})
}
return s.AppendHistory(ctx, correlationID, entry)
```

The `SlipStore` interface, `slippytest/mock_store.go`, and all callers are **unchanged**.

---

## Verification

```
go build ./slippy/...  ✅
go test ./slippy/...   ✅  (ok  github.com/MyCarrier-DevOps/goLibMyCarrier/slippy  2.856s)
go test ./slippy/slippytest/...  ✅
```

---

## Outstanding / Follow-up

The `be202550` (AQAupdate) slip is **also stuck but for a separate reason**: `MC.Invoice/non-prod-deploy.yaml` is `workflow_dispatch` only (manual trigger). The `dev_deploy` step was never submitted for that branch — no "waiting for: builds" entry exists in its `state_history`. That is a separate operational issue unrelated to this fix.

---

## Extra Changes

`slippy/default.json` - was updated to have a full completed example of pipeline config