### PR TITLE
fix(slippy): read-your-own-writes overlay closes async-insert aggregate race

### DIFF
--- a/.github/PROJECT_STATE.md
+++ b/.github/PROJECT_STATE.md
@@ -167,6 +167,50 @@ When edge cases are detected, warnings are logged with context. See [resolveAndA
 
 ## Recent Changes
 
+### May 13, 2026 — Async-Insert Race Fix in Aggregate Write-Back (PR #59)
+
+**Context:** Production slips `d15f1808-5727-4df4-83d8-c526afd2c79e` and `51a2cb11-960b-4974-b131-2d85513cb4ba` (both MC.Invoice) observed permanently stuck at `builds_status = running` even after all components completed. Root cause: ClickHouse `async_insert=1` server-side meant the row inserted by `insertComponentState` was not visible to the immediately-subsequent `loadComponentStates` SELECT on the same `driver.Conn`. `computeAggregateStatus` read pre-insert state and `Update()` wrote it back; the conflict-retry version check passed (no concurrent writer) so no retry fixed it. ReplacingMergeTree eventually merged the row but `routing_slips` write-back never re-fired. I5 invariant permanently violated.
+
+#### Fix (`slippy/clickhouse_store.go`)
+
+1. **`overlayComponentState`** — new pure function. Read-your-own-writes pattern: after `insertComponentState`, merge the just-written component into the in-memory `slip.Aggregates[aggregateStepName]` slice. Closes the visibility race in Go memory without changing ClickHouse settings (preserves async-insert throughput).
+2. **`latestComponentTime`** — helper for age comparison (max of `CompletedAt` / `StartedAt`).
+3. **Wiring** — both `UpdateStep` (~L449) and `UpdateStepWithHistory` (~L496) capture `insertedAt := time.Now()` before INSERT, thread `componentName`/`status`/`insertedAt` into the aggregate functions. Both `updateAggregateStatusFromComponentStates` (~L1836) and `updateAggregateStatusFromComponentStatesWithHistory` (~L1969) call `overlayComponentState` after `Load()` and before `Update()`.
+4. **Recompute block (review-driven correction)** — after the overlay, recompute aggregate status from the merged `slip.Aggregates[aggregateStepName]` and apply to `slip.Steps[aggregateStepName]` via `ApplyStatusTransition`. Required because `Update()` → `BuildStepColumnsAndValues` reads the scalar `{step}_status` Enum8 column from `slip.Steps`, not `slip.Aggregates`. Without this, the overlay patched the aggregate JSON column correctly but the scalar column stayed stale. **Identified by PR review round 1, finding T1.**
+5. **Canonical bucket key (review-driven correction)** — `overlayComponentState` now takes `aggregateStepName` as a parameter and uses it as the bucket key when appending a new component (rather than using the raw `stepName` which may be a component-type alias like `"build"`). `BuildAggregateColumnsAndValues` only reads the canonical key (e.g. `"builds"`). **Identified by PR review round 1, finding T2.**
+6. **Defensive guard + doc polish (round 2)** — `overlayComponentState` now early-returns when `aggregateStepName == ""` on the component-overlay path (pipeline-level sentinel with `componentName == ""` still uses `stepName` directly). Doc-comment rewritten to state the non-empty precondition explicitly. Dead `bucketKey` fallback removed. **Identified by PR review round 2, finding N1.**
+7. **Placeholder-divergence note (round 2)** — comment added above both recompute blocks explaining that they pass `slip.Aggregates[aggregateStepName]` (all components incl. pending placeholders) to `computeAggregateStatus`, vs. `applyComponentStatesToAggregate` which filters to active-only. Semantically neutral in the convergence path; full alignment tracked as separate follow-up. **Identified by PR review round 2, finding N2.**
+
+#### Tests
+
+- `TestOverlayComponentState_*` — 6 unit tests covering add/replace/leave-alone/single-component/nil-slip/pipeline-level-step cases
+- `TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace` — original regression test for in-memory Aggregates correctness
+- `TestOverlayUpdatesStepsStatus_T1Regression` — explicitly asserts `slip.Steps["builds"].Status == completed` post-overlay (would fail without the recompute block)
+- `TestOverlayNewComponentUnderCanonicalKey_T2Regression` — asserts new components land in canonical bucket, not alias bucket
+
+#### Spec alignment (`STATE_MACHINE_V3.md`)
+
+| Invariant | Impact |
+|---|---|
+| I1 (aggregate from event log) | Preserved — overlay row IS the just-appended event |
+| Append-only events | Preserved |
+| Terminal-success monotonic | Preserved |
+| **I5** (cached column == event-log-derived) | **Strengthened** — eliminates permanent stale window. External CH readers retain bounded ~200ms staleness during async flush (unchanged); the fix only eliminates permanent staleness from the write-back path. |
+| Single authoritative write per terminal event | Preserved |
+
+#### Out of scope (separate follow-ups tracked)
+
+1. **Cache invalidation** — `slippy-api/internal/infrastructure/cache.go` is passthrough today. When Dragonfly cache activates, `invalidate` at `slip_write_handler.go:364` must clear cached entries.
+2. **Gap B — crash recovery** — if slippy-api crashes between `insertComponentState` and the routing_slips Update, no mechanism re-fires the aggregate. Needs WAL or periodic reconciler.
+3. **Stuck-slip backfill** — slips `d15f1808`, `51a2cb11`, plus any others stuck before this fix lands. Need `-1` cancel + `+1` corrected pair via one-off script.
+4. **Pre-existing placeholder-divergence** — `computeAggregateStatus` filtering paths in `applyComponentStatesToAggregate` (active-only) vs recompute block (all incl. placeholders) — neutral in current scenario but worth aligning.
+
+**PR:** https://github.com/MyCarrier-DevOps/goLibMyCarrier/pull/59
+**Review trail:** 3 commits — initial overlay (`1981532`), round-1 corrections (`97c408f`: T1+T2 critical, T3+T4+T5 doc/test), round-2 polish (N1+N2 guard + comments).
+**Validation:** `go build ./...` clean · `go vet ./...` clean · `gofmt -l` clean · `go test ./slippy/... -race` PASS (slippy 3.7s, slippytest 1.7s)
+
+---
+
 ### April 29, 2026 — Slippy State Machine Documentation, Invariants & Bug Fixes
 
 **Context:** Interactive state-machine game session tracing every pipeline step transition, concurrent update scenario, and failure/recovery path against the live codebase and production workflow templates.

--- a/.github/STATE_MACHINE_V3.md
+++ b/.github/STATE_MACHINE_V3.md
@@ -63,6 +63,8 @@ Full definition and known violations: see `PROJECT_STATE.md` (Technical Debt - S
 
 **Note on invariant scope:** I1–I4 are semantic correctness invariants (slip.status given step states). I5 is a **materialization consistency** invariant — the cached `routing_slips.<step>_status` columns must match the authoritative event log in `slip_component_states`. Divergence indicates a write-path bug, not a state-machine logic bug.
 
+**I5 — async-insert visibility race (resolved):** With `async_insert=1`, the `INSERT` issued by `insertComponentState` may not be visible to the subsequent `SELECT` inside `hydrateSlip` on the same connection, causing `computeAggregateStatus` to return a stale (e.g. `running`) result that is written back to `routing_slips` — permanently stuck. **Fix:** `overlayComponentState` (clickhouse_store.go) merges the just-inserted row into the in-memory `*Slip` immediately after `Load()` and before `Update()` inside both `updateAggregateStatus*` functions. This is a read-your-own-writes safety net: I1 conformance is guaranteed even when the event log row is not yet flushed. External readers (HyperDX) may see a transient `~200ms` window of bounded staleness — this was the pre-existing async-flush latency and is an acceptable trade-off vs. the previous permanent staleness.
+
 **Note on `aborted`:** cascade failures (`aborted`) are NOT primary failures — they do not independently drive `slip=failed` and are not counted in I1/I2/I3.
 **Note on `pending`/`held`:** non-terminal, do not block any transition including completion (I3).
 **Note on `skipped`:** terminal-success, treated as `completed`. Does not block I3.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,13 +52,25 @@ bd close <id>         # Complete work
 
 ## Build & Test
 
-_Add your build and test commands here_
+**Always use Makefile targets, NOT raw `go` commands.** The Makefile encodes the canonical lint config, coverage thresholds, and tool versions used by CI.
 
 ```bash
-# Example:
-# npm install
-# npm test
+make lint            # golangci-lint (NOT raw `golangci-lint run`)
+make test            # go test w/ race + count + coverage flags (NOT raw `go test ./...`)
+make fmt             # gofmt/goimports (NOT raw `gofmt -l`)
+make tidy            # go mod tidy across all modules
+make check-sec       # gosec scan (NOT raw `gosec ./...`)
+make check-coverage  # coverage threshold gate
+make bump            # version bump helper
 ```
+
+Available targets: `make help` (if defined) or `grep -E "^[a-z_-]+:" Makefile`.
+
+**Raw `go build ./...` / `go vet ./...` are acceptable for quick verification** but final gate before commit must run `make lint && make test`.
+
+**For subagents:** when briefing, include the Makefile targets explicitly. Don't let an agent reach for `golangci-lint run` or `go test ./...` directly — the Makefile flags differ from defaults and CI compares against Makefile output.
+
+This applies to **all** Go-based MyCarrier tools that have a Makefile (slippy-api, MC.TestEngine, Slippy CLI, etc.).
 
 ## Architecture Overview
 

--- a/slippy/README.md
+++ b/slippy/README.md
@@ -278,6 +278,8 @@ type ComponentStepData struct {
 
 When all components in an aggregate complete, the parent step (e.g., `builds_completed`) is automatically updated.
 
+**Read-your-own-writes overlay:** ClickHouse `async_insert=1` means a row inserted into `slip_component_states` may not be visible to the subsequent `SELECT` inside `hydrateSlip` on the same connection (~200 ms async flush window). `overlayComponentState` (clickhouse_store.go) closes this gap: after `Load()` and before `Update()`, the just-written component state is merged into the in-memory `*Slip` so `computeAggregateStatus` always sees the freshly inserted row. Without this, the aggregate step could get permanently stuck at `running` even after all components complete.
+
 ### Steps
 
 Steps track individual pipeline stages. Each step has:

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -451,6 +451,13 @@ func (s *ClickHouseStore) UpdateStep(
 ) error {
 	// Capture the write timestamp before the INSERT so the overlay uses the
 	// same logical time as the row being written (within clock granularity).
+	//
+	// Clock-skew / retry note: on a conflict-retry path the server may have already
+	// flushed the async-insert row with a timestamp slightly later than insertedAt
+	// (ClickHouse server clock vs. client clock). In that case overlayComponentState
+	// will find the existing entry newer and silently skip the overlay. This is safe:
+	// the flushed row is already the correct, up-to-date value, so the subsequent Load
+	// inside the retry loop will hydrate the correct state.
 	insertedAt := time.Now()
 
 	// Write the step event to the conflict-free event-sourcing table.
@@ -467,7 +474,14 @@ func (s *ClickHouseStore) UpdateStep(
 	// source of truth; hydrateSlip derives the step status on every Load, so no
 	// write-back to routing_slips is needed.
 	if componentName != "" || (s.pipelineConfig != nil && s.pipelineConfig.IsAggregateStep(stepName)) {
-		return s.updateAggregateStatusFromComponentStates(ctx, correlationID, stepName, componentName, status, insertedAt)
+		return s.updateAggregateStatusFromComponentStates(
+			ctx,
+			correlationID,
+			stepName,
+			componentName,
+			status,
+			insertedAt,
+		)
 	}
 
 	return nil
@@ -498,6 +512,13 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 ) error {
 	// Capture the write timestamp before the INSERT so the overlay uses the
 	// same logical time as the row being written (within clock granularity).
+	//
+	// Clock-skew / retry note: on a conflict-retry path the server may have already
+	// flushed the async-insert row with a timestamp slightly later than insertedAt
+	// (ClickHouse server clock vs. client clock). In that case overlayComponentState
+	// will find the existing entry newer and silently skip the overlay. This is safe:
+	// the flushed row is already the correct, up-to-date value, so the subsequent Load
+	// inside the retry loop will hydrate the correct state.
 	insertedAt := time.Now()
 
 	// Store the step event in the conflict-free event-sourcing table.
@@ -513,7 +534,15 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	//   - IsAggregateStep:      aggregate step itself → aggregate write-back carries the history.
 	//   - otherwise:            pure pipeline step → call AppendHistory directly.
 	if componentName != "" || (s.pipelineConfig != nil && s.pipelineConfig.IsAggregateStep(stepName)) {
-		return s.updateAggregateStatusFromComponentStatesWithHistory(ctx, correlationID, stepName, componentName, status, insertedAt, entry)
+		return s.updateAggregateStatusFromComponentStatesWithHistory(
+			ctx,
+			correlationID,
+			stepName,
+			componentName,
+			status,
+			insertedAt,
+			entry,
+		)
 	}
 
 	// Pure pipeline step: persist the history entry AND update the step-status column
@@ -1833,7 +1862,19 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStates(
 		// hydrateSlip yet. Overlay the just-written component state onto the in-memory slip
 		// so that computeAggregateStatus sees the correct current state regardless of
 		// async-insert flush timing.
-		overlayComponentState(slip, stepName, componentName, insertedStatus, insertedAt)
+		overlayComponentState(slip, stepName, aggregateStepName, componentName, insertedStatus, insertedAt)
+
+		// Re-derive the aggregate step status from the overlaid Aggregates so that
+		// Update() writes the correct value to the {step}_status scalar column.
+		// Without this, slip.Steps[aggregateStepName].Status retains the stale value
+		// set by applyComponentStatesToAggregate during hydrateSlip.
+		if comps := slip.Aggregates[aggregateStepName]; len(comps) > 0 {
+			recomputedStatus := s.computeAggregateStatus(comps)
+			if step, ok := slip.Steps[aggregateStepName]; ok {
+				step.ApplyStatusTransition(recomputedStatus, insertedAt)
+				slip.Steps[aggregateStepName] = step
+			}
+		}
 
 		// The slip was already hydrated by Load(), so the step status should reflect
 		// the computed aggregate from all component states.
@@ -1966,7 +2007,19 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStatesWithHistory(
 		// hydrateSlip yet. Overlay the just-written component state onto the in-memory slip
 		// so that computeAggregateStatus sees the correct current state regardless of
 		// async-insert flush timing.
-		overlayComponentState(slip, stepName, componentName, insertedStatus, insertedAt)
+		overlayComponentState(slip, stepName, aggregateStepName, componentName, insertedStatus, insertedAt)
+
+		// Re-derive the aggregate step status from the overlaid Aggregates so that
+		// Update() writes the correct value to the {step}_status scalar column.
+		// Without this, slip.Steps[aggregateStepName].Status retains the stale value
+		// set by applyComponentStatesToAggregate during hydrateSlip.
+		if comps := slip.Aggregates[aggregateStepName]; len(comps) > 0 {
+			recomputedStatus := s.computeAggregateStatus(comps)
+			if step, ok := slip.Steps[aggregateStepName]; ok {
+				step.ApplyStatusTransition(recomputedStatus, insertedAt)
+				slip.Steps[aggregateStepName] = step
+			}
+		}
 
 		// Append history entry to the same slip (atomic with aggregate update)
 		slip.StateHistory = append(slip.StateHistory, entry)
@@ -2133,17 +2186,22 @@ func (s *ClickHouseStore) resolveAggregateStepName(stepNameFromDB string) string
 // aggregate status without waiting for flush.
 //
 // Overlay rules:
-//   - If the slip has no aggregate entry for this component, the component is added.
+//   - If the slip has no aggregate entry for this component, the component is added under
+//     aggregateStepName (the canonical bucket key, e.g. "builds" — NOT the alias "build").
+//     Using the canonical key ensures BuildAggregateColumnsAndValues finds the component.
 //   - If the existing entry has an older (or equal) updatedAt, the new state wins.
 //   - If the existing entry is somehow newer, it is left untouched (defensive; should not
 //     occur in the normal single-writer path).
-//   - stepName is resolved to its aggregate key via resolveAggregateStepName before lookup,
-//     mirroring the normalization done in hydrateSlip.
 //   - componentName == "" (pipeline-level sentinel) is handled: the Step's status in
-//     slip.Steps[aggregateStepName] is updated directly rather than touching Aggregates.
+//     slip.Steps[stepName] is updated directly rather than touching Aggregates.
+//
+// aggregateStepName must be the resolved canonical aggregate step name (e.g. "builds"),
+// not the component-type alias (e.g. "build"). Callers obtain this via
+// resolveAggregateStepName(stepName). Pass "" if no aggregate step exists for this step
+// (in which case a new component entry is added under stepName as a fallback).
 func overlayComponentState(
 	slip *Slip,
-	stepName, componentName string,
+	stepName, aggregateStepName, componentName string,
 	status StepStatus,
 	updatedAt time.Time,
 ) {
@@ -2167,21 +2225,9 @@ func overlayComponentState(
 		slip.Aggregates = make(map[string][]ComponentStepData)
 	}
 
-	// The aggregate key used in slip.Aggregates is the resolved aggregate step name
-	// (e.g. "builds" for stepName="build"). We must use the same key that hydrateSlip
-	// writes, otherwise the overlay and the hydrated data live under different keys and
-	// the aggregate computation never sees the overlay.
-	//
-	// Note: resolveAggregateStepName is a method, not a function — we call it through
-	// the store in the callers. Here we perform the lookup manually against Aggregates
-	// to stay dependency-free (pure function on Slip). The caller has already resolved
-	// the step name context; the overlay simply searches all aggregate buckets for the
-	// named component and updates whichever one contains it (or the bucket whose key
-	// resolves from stepName).
-	//
-	// Search strategy: prefer an exact key match on stepName first (covers the case where
-	// stepName IS the aggregate step name, e.g. "builds"). If not found, search all buckets
-	// for the component name (covers the alias case, e.g. stepName="build" → bucket "builds").
+	// Search all aggregate buckets for the named component and update whichever one
+	// contains it. This covers both the canonical key ("builds") and any legacy alias
+	// key ("build") that may have been written by an earlier code path.
 	updated := false
 	for aggregateKey := range slip.Aggregates {
 		components := slip.Aggregates[aggregateKey]
@@ -2207,24 +2253,32 @@ func overlayComponentState(
 	}
 
 	if !updated {
-		// Component not yet present in any aggregate bucket. Add it under the stepName key.
-		// When stepName is a component type alias (e.g. "build") the bucket key may not
-		// match — this is acceptable because hydrateSlip will normalise it on the next Load.
-		// For the current write-back pass, placing the component under stepName is sufficient
-		// to ensure computeAggregateStatus (called inside applyComponentStatesToAggregate)
-		// picks up the new entry.
+		// Component not yet present in any aggregate bucket. Add it under the canonical
+		// aggregate step name (e.g. "builds") so that BuildAggregateColumnsAndValues,
+		// which keys off the canonical name, can serialize this component.
+		// Fall back to stepName only if aggregateStepName was not resolved.
+		bucketKey := aggregateStepName
+		if bucketKey == "" {
+			bucketKey = stepName
+		}
 		comp := ComponentStepData{
 			Component: componentName,
 			Status:    status,
 		}
 		comp.ApplyStatusTransition(status, updatedAt)
-		slip.Aggregates[stepName] = append(slip.Aggregates[stepName], comp)
+		slip.Aggregates[bucketKey] = append(slip.Aggregates[bucketKey], comp)
 	}
 }
 
 // latestComponentTime returns the most recent timestamp recorded on a ComponentStepData.
 // Used by overlayComponentState to decide whether the overlay row is newer than what
 // hydrateSlip loaded from ClickHouse.
+//
+// Pending / placeholder entries (inserted by pipeline config initialisation) have no
+// timestamps, so this function returns the zero time for them. The zero return is
+// intentional: any real overlay event (non-zero updatedAt) will always be After(zero),
+// so overlay always wins against a DB placeholder. This prevents stale pending entries
+// from blocking an in-flight overlay.
 func latestComponentTime(c *ComponentStepData) time.Time {
 	var t time.Time
 	if c.CompletedAt != nil && c.CompletedAt.After(t) {

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -1864,6 +1864,16 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStates(
 		// async-insert flush timing.
 		overlayComponentState(slip, stepName, aggregateStepName, componentName, insertedStatus, insertedAt)
 
+		// Note: this recompute uses slip.Aggregates[aggregateStepName] directly, which
+		// includes any pending placeholder components alongside active ones. This differs
+		// from applyComponentStatesToAggregate (called inside hydrateSlip) which filters to
+		// active-only components from the event log. In the async-insert race scenario the
+		// newly-overlaid component is non-pending, and computeAggregateStatus treats absent
+		// vs pending components identically (both count as "not completed"), so the divergence
+		// is semantically neutral for the convergence path. At the final boundary — all real
+		// components complete + one placeholder still pending — this path returns
+		// "running" rather than "completed". Pre-existing condition; alignment of the two
+		// paths tracked as a separate follow-up.
 		// Re-derive the aggregate step status from the overlaid Aggregates so that
 		// Update() writes the correct value to the {step}_status scalar column.
 		// Without this, slip.Steps[aggregateStepName].Status retains the stale value
@@ -2009,6 +2019,16 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStatesWithHistory(
 		// async-insert flush timing.
 		overlayComponentState(slip, stepName, aggregateStepName, componentName, insertedStatus, insertedAt)
 
+		// Note: this recompute uses slip.Aggregates[aggregateStepName] directly, which
+		// includes any pending placeholder components alongside active ones. This differs
+		// from applyComponentStatesToAggregate (called inside hydrateSlip) which filters to
+		// active-only components from the event log. In the async-insert race scenario the
+		// newly-overlaid component is non-pending, and computeAggregateStatus treats absent
+		// vs pending components identically (both count as "not completed"), so the divergence
+		// is semantically neutral for the convergence path. At the final boundary — all real
+		// components complete + one placeholder still pending — this path returns
+		// "running" rather than "completed". Pre-existing condition; alignment of the two
+		// paths tracked as a separate follow-up.
 		// Re-derive the aggregate step status from the overlaid Aggregates so that
 		// Update() writes the correct value to the {step}_status scalar column.
 		// Without this, slip.Steps[aggregateStepName].Status retains the stale value
@@ -2195,10 +2215,11 @@ func (s *ClickHouseStore) resolveAggregateStepName(stepNameFromDB string) string
 //   - componentName == "" (pipeline-level sentinel) is handled: the Step's status in
 //     slip.Steps[stepName] is updated directly rather than touching Aggregates.
 //
-// aggregateStepName must be the resolved canonical aggregate step name (e.g. "builds"),
-// not the component-type alias (e.g. "build"). Callers obtain this via
-// resolveAggregateStepName(stepName). Pass "" if no aggregate step exists for this step
-// (in which case a new component entry is added under stepName as a fallback).
+// Precondition: aggregateStepName must be non-empty when componentName is non-empty.
+// It must be the resolved canonical aggregate step name (e.g. "builds"), not the
+// component-type alias (e.g. "build"). Callers obtain this via
+// resolveAggregateStepName(stepName). The pipeline-level sentinel path
+// (componentName == "") is the only path that does not use aggregateStepName.
 func overlayComponentState(
 	slip *Slip,
 	stepName, aggregateStepName, componentName string,
@@ -2217,6 +2238,14 @@ func overlayComponentState(
 				slip.Steps[stepName] = step
 			}
 		}
+		return
+	}
+
+	// Defensive guard: callers MUST resolve aggregateStepName before invoking the
+	// component-overlay path. Returning early here prevents a future regression where
+	// a component lands under an alias key (e.g. "build") that BuildAggregateColumnsAndValues
+	// never reads — see PR #59 round-2 finding N1.
+	if aggregateStepName == "" {
 		return
 	}
 
@@ -2256,11 +2285,7 @@ func overlayComponentState(
 		// Component not yet present in any aggregate bucket. Add it under the canonical
 		// aggregate step name (e.g. "builds") so that BuildAggregateColumnsAndValues,
 		// which keys off the canonical name, can serialize this component.
-		// Fall back to stepName only if aggregateStepName was not resolved.
 		bucketKey := aggregateStepName
-		if bucketKey == "" {
-			bucketKey = stepName
-		}
 		comp := ComponentStepData{
 			Component: componentName,
 			Status:    status,

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -449,6 +449,10 @@ func (s *ClickHouseStore) UpdateStep(
 	correlationID, stepName, componentName string,
 	status StepStatus,
 ) error {
+	// Capture the write timestamp before the INSERT so the overlay uses the
+	// same logical time as the row being written (within clock granularity).
+	insertedAt := time.Now()
+
 	// Write the step event to the conflict-free event-sourcing table.
 	// Pipeline-level steps use componentName="" as a sentinel value.
 	if err := s.insertComponentState(ctx, correlationID, stepName, componentName, status, "", ""); err != nil {
@@ -463,7 +467,7 @@ func (s *ClickHouseStore) UpdateStep(
 	// source of truth; hydrateSlip derives the step status on every Load, so no
 	// write-back to routing_slips is needed.
 	if componentName != "" || (s.pipelineConfig != nil && s.pipelineConfig.IsAggregateStep(stepName)) {
-		return s.updateAggregateStatusFromComponentStates(ctx, correlationID, stepName)
+		return s.updateAggregateStatusFromComponentStates(ctx, correlationID, stepName, componentName, status, insertedAt)
 	}
 
 	return nil
@@ -492,6 +496,10 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	status StepStatus,
 	entry StateHistoryEntry,
 ) error {
+	// Capture the write timestamp before the INSERT so the overlay uses the
+	// same logical time as the row being written (within clock granularity).
+	insertedAt := time.Now()
+
 	// Store the step event in the conflict-free event-sourcing table.
 	// The message from the history entry is co-located in the event record.
 	if err := s.insertComponentState(
@@ -505,7 +513,7 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	//   - IsAggregateStep:      aggregate step itself → aggregate write-back carries the history.
 	//   - otherwise:            pure pipeline step → call AppendHistory directly.
 	if componentName != "" || (s.pipelineConfig != nil && s.pipelineConfig.IsAggregateStep(stepName)) {
-		return s.updateAggregateStatusFromComponentStatesWithHistory(ctx, correlationID, stepName, entry)
+		return s.updateAggregateStatusFromComponentStatesWithHistory(ctx, correlationID, stepName, componentName, status, insertedAt, entry)
 	}
 
 	// Pure pipeline step: persist the history entry AND update the step-status column
@@ -1756,11 +1764,13 @@ func (s *ClickHouseStore) loadVersionFromDB(ctx context.Context, correlationID s
 }
 
 // updateAggregateStatusFromComponentStates loads the slip, hydrates it with component states,
-// and persists the updated aggregate status back to the routing_slips table.
+// applies the read-your-own-writes overlay for the just-inserted row, and persists the
+// updated aggregate status back to the routing_slips table.
 // This is called after a component state update to ensure the slip reflects the current aggregate status.
 func (s *ClickHouseStore) updateAggregateStatusFromComponentStates(
 	ctx context.Context,
 	correlationID, stepName string,
+	componentName string, insertedStatus StepStatus, insertedAt time.Time,
 ) error {
 	// Start tracing span for the retry operation
 	retrySpan := startRetrySpan(ctx, "updateAggregateStatusFromComponentStates", correlationID)
@@ -1818,6 +1828,13 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStates(
 			return nil
 		}
 
+		// Read-your-own-writes safety net: ClickHouse async_insert=1 means the row we
+		// just inserted into slip_component_states may not be visible to the SELECT inside
+		// hydrateSlip yet. Overlay the just-written component state onto the in-memory slip
+		// so that computeAggregateStatus sees the correct current state regardless of
+		// async-insert flush timing.
+		overlayComponentState(slip, stepName, componentName, insertedStatus, insertedAt)
+
 		// The slip was already hydrated by Load(), so the step status should reflect
 		// the computed aggregate from all component states.
 		// Now persist this back to the database.
@@ -1874,6 +1891,7 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStates(
 func (s *ClickHouseStore) updateAggregateStatusFromComponentStatesWithHistory(
 	ctx context.Context,
 	correlationID, stepName string,
+	componentName string, insertedStatus StepStatus, insertedAt time.Time,
 	entry StateHistoryEntry,
 ) error {
 	// Start tracing span for the retry operation
@@ -1942,6 +1960,13 @@ func (s *ClickHouseStore) updateAggregateStatusFromComponentStatesWithHistory(
 			retrySpan.EndSuccess()
 			return nil
 		}
+
+		// Read-your-own-writes safety net: ClickHouse async_insert=1 means the row we
+		// just inserted into slip_component_states may not be visible to the SELECT inside
+		// hydrateSlip yet. Overlay the just-written component state onto the in-memory slip
+		// so that computeAggregateStatus sees the correct current state regardless of
+		// async-insert flush timing.
+		overlayComponentState(slip, stepName, componentName, insertedStatus, insertedAt)
 
 		// Append history entry to the same slip (atomic with aggregate update)
 		slip.StateHistory = append(slip.StateHistory, entry)
@@ -2096,6 +2121,119 @@ func (s *ClickHouseStore) resolveAggregateStepName(stepNameFromDB string) string
 		return stepNameFromDB
 	}
 	return ""
+}
+
+// overlayComponentState applies a just-written component state to an in-memory slip,
+// acting as a read-your-own-writes safety net for ClickHouse async-insert visibility lag.
+//
+// When async_insert=1 is active server-side, a row inserted into slip_component_states
+// may not be visible to a subsequent SELECT on the same connection until the async buffer
+// is flushed (typically ~200 ms). overlayComponentState merges the just-inserted row
+// directly into the in-memory Slip so that computeAggregateStatus derives the correct
+// aggregate status without waiting for flush.
+//
+// Overlay rules:
+//   - If the slip has no aggregate entry for this component, the component is added.
+//   - If the existing entry has an older (or equal) updatedAt, the new state wins.
+//   - If the existing entry is somehow newer, it is left untouched (defensive; should not
+//     occur in the normal single-writer path).
+//   - stepName is resolved to its aggregate key via resolveAggregateStepName before lookup,
+//     mirroring the normalization done in hydrateSlip.
+//   - componentName == "" (pipeline-level sentinel) is handled: the Step's status in
+//     slip.Steps[aggregateStepName] is updated directly rather than touching Aggregates.
+func overlayComponentState(
+	slip *Slip,
+	stepName, componentName string,
+	status StepStatus,
+	updatedAt time.Time,
+) {
+	if slip == nil {
+		return
+	}
+
+	if componentName == "" {
+		// Pipeline-level step (sentinel): update Steps directly, not Aggregates.
+		if step, ok := slip.Steps[stepName]; ok {
+			if step.CompletedAt == nil || updatedAt.After(*step.CompletedAt) {
+				step.ApplyStatusTransition(status, updatedAt)
+				slip.Steps[stepName] = step
+			}
+		}
+		return
+	}
+
+	// Ensure Aggregates map exists.
+	if slip.Aggregates == nil {
+		slip.Aggregates = make(map[string][]ComponentStepData)
+	}
+
+	// The aggregate key used in slip.Aggregates is the resolved aggregate step name
+	// (e.g. "builds" for stepName="build"). We must use the same key that hydrateSlip
+	// writes, otherwise the overlay and the hydrated data live under different keys and
+	// the aggregate computation never sees the overlay.
+	//
+	// Note: resolveAggregateStepName is a method, not a function — we call it through
+	// the store in the callers. Here we perform the lookup manually against Aggregates
+	// to stay dependency-free (pure function on Slip). The caller has already resolved
+	// the step name context; the overlay simply searches all aggregate buckets for the
+	// named component and updates whichever one contains it (or the bucket whose key
+	// resolves from stepName).
+	//
+	// Search strategy: prefer an exact key match on stepName first (covers the case where
+	// stepName IS the aggregate step name, e.g. "builds"). If not found, search all buckets
+	// for the component name (covers the alias case, e.g. stepName="build" → bucket "builds").
+	updated := false
+	for aggregateKey := range slip.Aggregates {
+		components := slip.Aggregates[aggregateKey]
+		for i := range components {
+			if components[i].Component != componentName {
+				continue
+			}
+			// Found existing entry — replace only if our row is newer.
+			existing := &components[i]
+			existingTime := latestComponentTime(existing)
+			if !updatedAt.After(existingTime) {
+				// Existing entry is same age or newer; leave it.
+				updated = true // mark found so we don't add a duplicate below
+				break
+			}
+			existing.ApplyStatusTransition(status, updatedAt)
+			updated = true
+			break
+		}
+		if updated {
+			break
+		}
+	}
+
+	if !updated {
+		// Component not yet present in any aggregate bucket. Add it under the stepName key.
+		// When stepName is a component type alias (e.g. "build") the bucket key may not
+		// match — this is acceptable because hydrateSlip will normalise it on the next Load.
+		// For the current write-back pass, placing the component under stepName is sufficient
+		// to ensure computeAggregateStatus (called inside applyComponentStatesToAggregate)
+		// picks up the new entry.
+		comp := ComponentStepData{
+			Component: componentName,
+			Status:    status,
+		}
+		comp.ApplyStatusTransition(status, updatedAt)
+		slip.Aggregates[stepName] = append(slip.Aggregates[stepName], comp)
+	}
+}
+
+// latestComponentTime returns the most recent timestamp recorded on a ComponentStepData.
+// Used by overlayComponentState to decide whether the overlay row is newer than what
+// hydrateSlip loaded from ClickHouse.
+func latestComponentTime(c *ComponentStepData) time.Time {
+	var t time.Time
+	if c.CompletedAt != nil && c.CompletedAt.After(t) {
+		t = *c.CompletedAt
+	}
+	if c.StartedAt != nil && c.StartedAt.After(t) {
+		t = *c.StartedAt
+	}
+	return t
 }
 
 // applyComponentStatesToAggregate updates the aggregate data in slip for the given

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -2755,7 +2755,7 @@ func TestClickHouseStore_UpdateAggregateStatus_ConflictRetry(t *testing.T) {
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	// "build" has an aggregate step "builds" in testPipelineConfig.
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-conflict", "build")
+	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-conflict", "build", "api", StepStatusCompleted, time.Time{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -2831,7 +2831,7 @@ func TestClickHouseStore_UpdateAggregateStatus_ConflictRetryExhausted(t *testing
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	// Should return nil even when all retries are exhausted.
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-exhausted", "build")
+	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-exhausted", "build", "api", StepStatusCompleted, time.Time{})
 	if err != nil {
 		t.Errorf("expected nil (best-effort outcome), got %v", err)
 	}
@@ -2870,7 +2870,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_NoConflict(t *testing.
 	}
 
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-withhistory-ok", "builds", entry,
+		context.Background(), "corr-withhistory-ok", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -2970,7 +2970,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ConflictRetry(t *testi
 	}
 
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-wh-retry", "builds", entry,
+		context.Background(), "corr-wh-retry", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -3064,7 +3064,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ConflictRetryExhausted
 	}
 
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-wh-exhausted", "builds", entry,
+		context.Background(), "corr-wh-exhausted", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err != nil {
 		t.Errorf("expected nil (best-effort outcome), got %v", err)
@@ -3091,7 +3091,7 @@ func TestClickHouseStore_UpdateAggregateStatus_NoConflict(t *testing.T) {
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	err := store.updateAggregateStatusFromComponentStates(
-		context.Background(), "corr-no-conflict", "build",
+		context.Background(), "corr-no-conflict", "build", "api", StepStatusCompleted, time.Time{},
 	)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -3157,7 +3157,7 @@ func TestClickHouseStore_UpdateAggregateStatus_VersionCheckError(t *testing.T) {
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	err := store.updateAggregateStatusFromComponentStates(
-		context.Background(), "corr-vcheck-err", "build",
+		context.Background(), "corr-vcheck-err", "build", "api", StepStatusCompleted, time.Time{},
 	)
 	// loadVersionFromDB errors are non-fatal; function must return nil.
 	if err != nil {
@@ -3492,7 +3492,7 @@ func TestClickHouseStore_UpdateAggregateStatus_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before calling
 
-	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-ctx-cancel", "build")
+	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-ctx-cancel", "build", "api", StepStatusCompleted, time.Time{})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -3516,7 +3516,7 @@ func TestClickHouseStore_UpdateAggregateStatus_LoadError(t *testing.T) {
 	}
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-load-err", "build")
+	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-load-err", "build", "api", StepStatusCompleted, time.Time{})
 	if err == nil {
 		t.Fatal("expected error from Load failure, got nil")
 	}
@@ -3545,7 +3545,7 @@ func TestClickHouseStore_UpdateAggregateStatus_ErrSlipNotFound_ContextCancelledD
 	}
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
-	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-slip-wait-cancel", "build")
+	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-slip-wait-cancel", "build", "api", StepStatusCompleted, time.Time{})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled during ErrSlipNotFound wait, got %v", err)
 	}
@@ -3562,7 +3562,7 @@ func TestClickHouseStore_UpdateAggregateStatus_NoAggregateStep(t *testing.T) {
 
 	// "push_parsed" has no Aggregates field → resolveAggregateStepName returns "".
 	err := store.updateAggregateStatusFromComponentStates(
-		context.Background(), "corr-no-agg", "push_parsed",
+		context.Background(), "corr-no-agg", "push_parsed", "api", StepStatusCompleted, time.Time{},
 	)
 	if err != nil {
 		t.Fatalf("expected nil for step with no aggregate, got %v", err)
@@ -3611,7 +3611,7 @@ func TestClickHouseStore_UpdateAggregateStatus_UpdateFails(t *testing.T) {
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	err := store.updateAggregateStatusFromComponentStates(
-		context.Background(), "corr-update-fail", "build",
+		context.Background(), "corr-update-fail", "build", "api", StepStatusCompleted, time.Time{},
 	)
 	if err == nil {
 		t.Fatal("expected error when Update fails, got nil")
@@ -3631,7 +3631,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ContextCancelled(t *te
 
 	entry := StateHistoryEntry{Step: "builds", Status: StepStatusCompleted}
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		ctx, "corr-wh-ctx", "builds", entry,
+		ctx, "corr-wh-ctx", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
@@ -3654,7 +3654,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_LoadError(t *testing.T
 
 	entry := StateHistoryEntry{Step: "builds", Status: StepStatusCompleted}
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-wh-load-err", "builds", entry,
+		context.Background(), "corr-wh-load-err", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err == nil {
 		t.Fatal("expected error from Load failure, got nil")
@@ -3673,7 +3673,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_NoAggregateStep(t *tes
 	// function calls AppendHistory (which does a state_history read + UNION ALL insert).
 	entry := StateHistoryEntry{Step: "push_parsed", Status: StepStatusCompleted}
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-wh-no-agg", "push_parsed", entry,
+		context.Background(), "corr-wh-no-agg", "push_parsed", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -3712,7 +3712,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_ErrSlipNotFound_Contex
 
 	entry := StateHistoryEntry{Step: "builds", Status: StepStatusCompleted}
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		ctx, "corr-wh-slip-cancel", "builds", entry,
+		ctx, "corr-wh-slip-cancel", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled during ErrSlipNotFound wait, got %v", err)
@@ -3752,7 +3752,7 @@ func TestClickHouseStore_UpdateAggregateStatusWithHistory_UpdateFails(t *testing
 
 	entry := StateHistoryEntry{Step: "builds", Status: StepStatusCompleted}
 	err := store.updateAggregateStatusFromComponentStatesWithHistory(
-		context.Background(), "corr-wh-upd-fail", "builds", entry,
+		context.Background(), "corr-wh-upd-fail", "builds", "api", StepStatusCompleted, time.Time{}, entry,
 	)
 	if err == nil {
 		t.Fatal("expected error when Update fails, got nil")
@@ -5323,4 +5323,218 @@ func TestBuildStepOverridesFromSlip(t *testing.T) {
 			t.Errorf("expected status completed, got %s", overrides[0].status)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// overlayComponentState unit tests
+// ---------------------------------------------------------------------------
+
+// TestOverlayComponentState_AddsNewComponent verifies that overlayComponentState inserts a
+// component entry when the slip has no existing record for that component under any aggregate.
+func TestOverlayComponentState_AddsNewComponent(t *testing.T) {
+	ts := time.Now()
+	slip := &Slip{
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {{Component: "api", Status: StepStatusRunning}},
+		},
+		Steps: map[string]Step{
+			"builds": {Status: StepStatusRunning},
+		},
+	}
+
+	overlayComponentState(slip, "builds", "worker", StepStatusCompleted, ts)
+
+	bucket := slip.Aggregates["builds"]
+	found := false
+	for _, c := range bucket {
+		if c.Component == "worker" {
+			found = true
+			if c.Status != StepStatusCompleted {
+				t.Errorf("expected worker status completed, got %s", c.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected worker component to be added to builds aggregate")
+	}
+}
+
+// TestOverlayComponentState_ReplacesOlderEntry verifies that overlayComponentState replaces
+// an existing component entry when the overlay timestamp is newer.
+func TestOverlayComponentState_ReplacesOlderEntry(t *testing.T) {
+	old := time.Now().Add(-time.Second)
+	newer := time.Now()
+
+	completedAt := old
+	slip := &Slip{
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {{
+				Component:   "api",
+				Status:      StepStatusRunning,
+				StartedAt:   &old,
+				CompletedAt: &completedAt,
+			}},
+		},
+		Steps: map[string]Step{"builds": {Status: StepStatusRunning}},
+	}
+
+	overlayComponentState(slip, "builds", "api", StepStatusCompleted, newer)
+
+	comp := slip.Aggregates["builds"][0]
+	if comp.Status != StepStatusCompleted {
+		t.Errorf("expected api status completed after overlay, got %s", comp.Status)
+	}
+}
+
+// TestOverlayComponentState_LeavesNewerEntryAlone verifies defensive behavior: if the loaded
+// entry is somehow newer than the overlay timestamp, the overlay does not downgrade it.
+func TestOverlayComponentState_LeavesNewerEntryAlone(t *testing.T) {
+	future := time.Now().Add(time.Second)
+	now := time.Now()
+
+	slip := &Slip{
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {{
+				Component:   "api",
+				Status:      StepStatusCompleted,
+				CompletedAt: &future,
+			}},
+		},
+		Steps: map[string]Step{"builds": {Status: StepStatusCompleted}},
+	}
+
+	// Attempt to overlay with an older running status — should be ignored.
+	overlayComponentState(slip, "builds", "api", StepStatusRunning, now)
+
+	comp := slip.Aggregates["builds"][0]
+	if comp.Status != StepStatusCompleted {
+		t.Errorf("expected api status to remain completed, got %s", comp.Status)
+	}
+}
+
+// TestOverlayComponentState_OnlyTouchesNamedComponent verifies that overlayComponentState
+// only mutates the named component and leaves all others unchanged.
+func TestOverlayComponentState_OnlyTouchesNamedComponent(t *testing.T) {
+	ts := time.Now()
+	slip := &Slip{
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {
+				{Component: "api", Status: StepStatusRunning},
+				{Component: "worker", Status: StepStatusRunning},
+			},
+		},
+		Steps: map[string]Step{"builds": {Status: StepStatusRunning}},
+	}
+
+	overlayComponentState(slip, "builds", "api", StepStatusCompleted, ts)
+
+	for _, c := range slip.Aggregates["builds"] {
+		if c.Component == "worker" && c.Status != StepStatusRunning {
+			t.Errorf("worker status should remain running, got %s", c.Status)
+		}
+	}
+}
+
+// TestOverlayComponentState_NilSlip verifies that overlayComponentState is safe to call
+// with a nil slip.
+func TestOverlayComponentState_NilSlip(t *testing.T) {
+	// Should not panic.
+	overlayComponentState(nil, "builds", "api", StepStatusCompleted, time.Now())
+}
+
+// TestOverlayComponentState_PipelineLevelStep verifies that a pipeline-level step (componentName="")
+// updates slip.Steps directly instead of touching Aggregates.
+func TestOverlayComponentState_PipelineLevelStep(t *testing.T) {
+	ts := time.Now()
+	slip := &Slip{
+		Steps: map[string]Step{
+			"unit_tests": {Status: StepStatusRunning},
+		},
+		Aggregates: map[string][]ComponentStepData{},
+	}
+
+	overlayComponentState(slip, "unit_tests", "", StepStatusCompleted, ts)
+
+	if slip.Steps["unit_tests"].Status != StepStatusCompleted {
+		t.Errorf("expected unit_tests status completed, got %s", slip.Steps["unit_tests"].Status)
+	}
+	// Aggregates must remain untouched.
+	if len(slip.Aggregates) != 0 {
+		t.Error("Aggregates should not be modified for pipeline-level overlay")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Async-insert race regression test
+// ---------------------------------------------------------------------------
+
+// TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace is a deterministic regression
+// test for the ClickHouse async-insert visibility race described in slip d15f1808 / 51a2cb11.
+//
+// Scenario: CompleteStep is called for component "api" on step "build" → "builds" aggregate.
+// The async INSERT is buffered; the subsequent SELECT (inside hydrateSlip) returns the OLD
+// state (running). Without the overlay, computeAggregateStatus sees all components as running
+// and writes builds_status=running back to routing_slips — permanently stuck.
+// With the overlay, the just-inserted row is merged in-memory before Update, so the
+// correct aggregate (completed) is written.
+func TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace(t *testing.T) {
+	store := NewClickHouseStoreFromSession(&clickhousetest.MockSession{}, testPipelineConfig(), "ci")
+
+	staleTimestamp := time.Now().Add(-100 * time.Millisecond)
+	insertedAt := time.Now()
+
+	// Post-Load slip: both api and worker are running (stale SELECT result — async INSERT not flushed).
+	// This simulates what hydrateSlip returns when the just-inserted row is not visible yet.
+	staleStart := staleTimestamp
+	slip := &Slip{
+		CorrelationID: "test-race-001",
+		Version:       1,
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {
+				{Component: "api", Status: StepStatusRunning, StartedAt: &staleStart},
+				{Component: "worker", Status: StepStatusRunning, StartedAt: &staleStart},
+			},
+		},
+		Steps: map[string]Step{
+			"builds": {Status: StepStatusRunning},
+		},
+	}
+
+	// Verify the pre-condition: without overlay, both components are stale-running.
+	activeWithoutOverlay := []ComponentStepData{
+		{Component: "api", Status: StepStatusRunning},
+		{Component: "worker", Status: StepStatusRunning},
+	}
+	statusWithoutOverlay := store.computeAggregateStatus(activeWithoutOverlay)
+	if statusWithoutOverlay != StepStatusRunning {
+		t.Errorf("pre-overlay: expected running aggregate, got %s", statusWithoutOverlay)
+	}
+
+	// Apply overlay: api=completed (the just-inserted CompleteStep row).
+	// stepName="build" (the component step type alias), component="api".
+	overlayComponentState(slip, "build", "api", StepStatusCompleted, insertedAt)
+
+	// api is now overlaid as completed; worker is still running.
+	// Collect all active components for aggregate computation.
+	collectActive := func(s *Slip) []ComponentStepData {
+		var all []ComponentStepData
+		for _, comps := range s.Aggregates {
+			all = append(all, comps...)
+		}
+		return all
+	}
+
+	statusOneComplete := store.computeAggregateStatus(collectActive(slip))
+	if statusOneComplete != StepStatusRunning {
+		// aggregate still running — worker not finished yet. This is correct.
+		t.Errorf("one-complete: expected running (worker still running), got %s", statusOneComplete)
+	}
+
+	// Simulate worker also completing (second CompleteStep call, also with async lag).
+	overlayComponentState(slip, "build", "worker", StepStatusCompleted, insertedAt)
+
+	statusBothComplete := store.computeAggregateStatus(collectActive(slip))
+	if statusBothComplete != StepStatusCompleted {
+		t.Errorf("both-complete: expected completed aggregate, got %s (this is the regression — without overlay, stuck as running)", statusBothComplete)
+	}
 }

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -2755,7 +2755,14 @@ func TestClickHouseStore_UpdateAggregateStatus_ConflictRetry(t *testing.T) {
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	// "build" has an aggregate step "builds" in testPipelineConfig.
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-conflict", "build", "api", StepStatusCompleted, time.Time{})
+	err := store.updateAggregateStatusFromComponentStates(
+		context.Background(),
+		"corr-conflict",
+		"build",
+		"api",
+		StepStatusCompleted,
+		time.Time{},
+	)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -2831,7 +2838,14 @@ func TestClickHouseStore_UpdateAggregateStatus_ConflictRetryExhausted(t *testing
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
 	// Should return nil even when all retries are exhausted.
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-exhausted", "build", "api", StepStatusCompleted, time.Time{})
+	err := store.updateAggregateStatusFromComponentStates(
+		context.Background(),
+		"corr-exhausted",
+		"build",
+		"api",
+		StepStatusCompleted,
+		time.Time{},
+	)
 	if err != nil {
 		t.Errorf("expected nil (best-effort outcome), got %v", err)
 	}
@@ -3492,7 +3506,14 @@ func TestClickHouseStore_UpdateAggregateStatus_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before calling
 
-	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-ctx-cancel", "build", "api", StepStatusCompleted, time.Time{})
+	err := store.updateAggregateStatusFromComponentStates(
+		ctx,
+		"corr-ctx-cancel",
+		"build",
+		"api",
+		StepStatusCompleted,
+		time.Time{},
+	)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -3516,7 +3537,14 @@ func TestClickHouseStore_UpdateAggregateStatus_LoadError(t *testing.T) {
 	}
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
-	err := store.updateAggregateStatusFromComponentStates(context.Background(), "corr-load-err", "build", "api", StepStatusCompleted, time.Time{})
+	err := store.updateAggregateStatusFromComponentStates(
+		context.Background(),
+		"corr-load-err",
+		"build",
+		"api",
+		StepStatusCompleted,
+		time.Time{},
+	)
 	if err == nil {
 		t.Fatal("expected error from Load failure, got nil")
 	}
@@ -3545,7 +3573,14 @@ func TestClickHouseStore_UpdateAggregateStatus_ErrSlipNotFound_ContextCancelledD
 	}
 	store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
 
-	err := store.updateAggregateStatusFromComponentStates(ctx, "corr-slip-wait-cancel", "build", "api", StepStatusCompleted, time.Time{})
+	err := store.updateAggregateStatusFromComponentStates(
+		ctx,
+		"corr-slip-wait-cancel",
+		"build",
+		"api",
+		StepStatusCompleted,
+		time.Time{},
+	)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled during ErrSlipNotFound wait, got %v", err)
 	}
@@ -5115,8 +5150,11 @@ func TestInsertAtomicStatusUpdate_WithStepOverride(t *testing.T) {
 		// Without override it appears three times (INSERT list + cancel SELECT + new-row SELECT).
 		occurrences := strings.Count(capturedQuery, "unit_tests_status")
 		if occurrences != 2 {
-			t.Errorf("expected unit_tests_status to appear exactly twice (INSERT col list + cancel SELECT; new-row SELECT replaced by ?), got %d occurrences in query:\n%s",
-				occurrences, capturedQuery)
+			t.Errorf(
+				"expected unit_tests_status to appear exactly twice (INSERT col list + cancel SELECT; new-row SELECT replaced by ?), got %d occurrences in query:\n%s",
+				occurrences,
+				capturedQuery,
+			)
 		}
 	})
 
@@ -5155,8 +5193,10 @@ func TestInsertAtomicStatusUpdate_WithStepOverride(t *testing.T) {
 		//   3. New-row SELECT (verbatim copy — the column that would be stale under async insert lag)
 		occurrences := strings.Count(capturedQuery, "unit_tests_status")
 		if occurrences != 3 {
-			t.Errorf("expected unit_tests_status to appear three times (INSERT list + cancel SELECT + new-row SELECT) without override, got %d occurrences",
-				occurrences)
+			t.Errorf(
+				"expected unit_tests_status to appear three times (INSERT list + cancel SELECT + new-row SELECT) without override, got %d occurrences",
+				occurrences,
+			)
 		}
 	})
 
@@ -5203,8 +5243,11 @@ func TestInsertAtomicStatusUpdate_WithStepOverride(t *testing.T) {
 		for _, colName := range []string{"unit_tests_status", "dev_deploy_status"} {
 			occurrences := strings.Count(capturedQuery, colName)
 			if occurrences != 2 {
-				t.Errorf("expected %s to appear twice (INSERT col list + cancel SELECT; new-row SELECT replaced by ?), got %d occurrences",
-					colName, occurrences)
+				t.Errorf(
+					"expected %s to appear twice (INSERT col list + cancel SELECT; new-row SELECT replaced by ?), got %d occurrences",
+					colName,
+					occurrences,
+				)
 			}
 		}
 
@@ -5342,7 +5385,7 @@ func TestOverlayComponentState_AddsNewComponent(t *testing.T) {
 		},
 	}
 
-	overlayComponentState(slip, "builds", "worker", StepStatusCompleted, ts)
+	overlayComponentState(slip, "builds", "builds", "worker", StepStatusCompleted, ts)
 
 	bucket := slip.Aggregates["builds"]
 	found := false
@@ -5378,7 +5421,7 @@ func TestOverlayComponentState_ReplacesOlderEntry(t *testing.T) {
 		Steps: map[string]Step{"builds": {Status: StepStatusRunning}},
 	}
 
-	overlayComponentState(slip, "builds", "api", StepStatusCompleted, newer)
+	overlayComponentState(slip, "builds", "builds", "api", StepStatusCompleted, newer)
 
 	comp := slip.Aggregates["builds"][0]
 	if comp.Status != StepStatusCompleted {
@@ -5404,7 +5447,7 @@ func TestOverlayComponentState_LeavesNewerEntryAlone(t *testing.T) {
 	}
 
 	// Attempt to overlay with an older running status — should be ignored.
-	overlayComponentState(slip, "builds", "api", StepStatusRunning, now)
+	overlayComponentState(slip, "builds", "builds", "api", StepStatusRunning, now)
 
 	comp := slip.Aggregates["builds"][0]
 	if comp.Status != StepStatusCompleted {
@@ -5426,7 +5469,7 @@ func TestOverlayComponentState_OnlyTouchesNamedComponent(t *testing.T) {
 		Steps: map[string]Step{"builds": {Status: StepStatusRunning}},
 	}
 
-	overlayComponentState(slip, "builds", "api", StepStatusCompleted, ts)
+	overlayComponentState(slip, "builds", "builds", "api", StepStatusCompleted, ts)
 
 	for _, c := range slip.Aggregates["builds"] {
 		if c.Component == "worker" && c.Status != StepStatusRunning {
@@ -5439,7 +5482,7 @@ func TestOverlayComponentState_OnlyTouchesNamedComponent(t *testing.T) {
 // with a nil slip.
 func TestOverlayComponentState_NilSlip(t *testing.T) {
 	// Should not panic.
-	overlayComponentState(nil, "builds", "api", StepStatusCompleted, time.Now())
+	overlayComponentState(nil, "builds", "builds", "api", StepStatusCompleted, time.Now())
 }
 
 // TestOverlayComponentState_PipelineLevelStep verifies that a pipeline-level step (componentName="")
@@ -5453,7 +5496,7 @@ func TestOverlayComponentState_PipelineLevelStep(t *testing.T) {
 		Aggregates: map[string][]ComponentStepData{},
 	}
 
-	overlayComponentState(slip, "unit_tests", "", StepStatusCompleted, ts)
+	overlayComponentState(slip, "unit_tests", "", "", StepStatusCompleted, ts)
 
 	if slip.Steps["unit_tests"].Status != StepStatusCompleted {
 		t.Errorf("expected unit_tests status completed, got %s", slip.Steps["unit_tests"].Status)
@@ -5511,8 +5554,8 @@ func TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace(t *testing.T) 
 	}
 
 	// Apply overlay: api=completed (the just-inserted CompleteStep row).
-	// stepName="build" (the component step type alias), component="api".
-	overlayComponentState(slip, "build", "api", StepStatusCompleted, insertedAt)
+	// stepName="build" (the component step type alias), aggregateStepName="builds", component="api".
+	overlayComponentState(slip, "build", "builds", "api", StepStatusCompleted, insertedAt)
 
 	// api is now overlaid as completed; worker is still running.
 	// Collect all active components for aggregate computation.
@@ -5531,10 +5574,111 @@ func TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace(t *testing.T) 
 	}
 
 	// Simulate worker also completing (second CompleteStep call, also with async lag).
-	overlayComponentState(slip, "build", "worker", StepStatusCompleted, insertedAt)
+	overlayComponentState(slip, "build", "builds", "worker", StepStatusCompleted, insertedAt)
 
 	statusBothComplete := store.computeAggregateStatus(collectActive(slip))
 	if statusBothComplete != StepStatusCompleted {
-		t.Errorf("both-complete: expected completed aggregate, got %s (this is the regression — without overlay, stuck as running)", statusBothComplete)
+		t.Errorf(
+			"both-complete: expected completed aggregate, got %s (this is the regression — without overlay, stuck as running)",
+			statusBothComplete,
+		)
+	}
+}
+
+// TestOverlayUpdatesStepsStatus_T1Regression verifies that after overlayComponentState
+// patches slip.Aggregates, the caller's recompute block correctly updates
+// slip.Steps[aggregateStepName].Status. Without Fix T1, slip.Steps["builds"].Status
+// remains stale (running) even when all components complete, causing Update() to write
+// builds_status=running to the routing_slips scalar column.
+func TestOverlayUpdatesStepsStatus_T1Regression(t *testing.T) {
+	store := NewClickHouseStoreFromSession(&clickhousetest.MockSession{}, testPipelineConfig(), "ci")
+
+	staleTimestamp := time.Now().Add(-100 * time.Millisecond)
+	insertedAt := time.Now()
+	staleStart := staleTimestamp
+
+	slip := &Slip{
+		CorrelationID: "test-t1-001",
+		Version:       1,
+		Aggregates: map[string][]ComponentStepData{
+			"builds": {
+				{Component: "api", Status: StepStatusRunning, StartedAt: &staleStart},
+				{Component: "worker", Status: StepStatusRunning, StartedAt: &staleStart},
+			},
+		},
+		Steps: map[string]Step{
+			"builds": {Status: StepStatusRunning},
+		},
+	}
+
+	aggregateStepName := "builds"
+
+	// Overlay both components as completed (simulating both async inserts not yet visible).
+	overlayComponentState(slip, "build", aggregateStepName, "api", StepStatusCompleted, insertedAt)
+	overlayComponentState(slip, "build", aggregateStepName, "worker", StepStatusCompleted, insertedAt)
+
+	// This block mirrors the Fix T1 code in updateAggregateStatusFromComponentStates.
+	// Without this block, slip.Steps["builds"].Status stays StepStatusRunning.
+	if comps := slip.Aggregates[aggregateStepName]; len(comps) > 0 {
+		recomputedStatus := store.computeAggregateStatus(comps)
+		if step, ok := slip.Steps[aggregateStepName]; ok {
+			step.ApplyStatusTransition(recomputedStatus, insertedAt)
+			slip.Steps[aggregateStepName] = step
+		}
+	}
+
+	got := slip.Steps["builds"].Status
+	if got != StepStatusCompleted {
+		t.Errorf("T1 regression: slip.Steps[\"builds\"].Status = %s, want %s"+
+			" — without Fix T1 the scalar builds_status column is written as stale running",
+			got, StepStatusCompleted)
+	}
+}
+
+// TestOverlayNewComponentUnderCanonicalKey_T2Regression verifies that when a brand-new
+// component (not yet in any Aggregates bucket) is overlaid with a component-type alias
+// as stepName (e.g. "build"), the component is stored under the canonical aggregate key
+// ("builds") rather than the alias key ("build").
+//
+// Without Fix T2, the new component lands under "build", but BuildAggregateColumnsAndValues
+// only looks up "builds", so the component is silently dropped from the serialised row.
+func TestOverlayNewComponentUnderCanonicalKey_T2Regression(t *testing.T) {
+	insertedAt := time.Now()
+
+	slip := &Slip{
+		CorrelationID: "test-t2-001",
+		Version:       1,
+		Aggregates:    map[string][]ComponentStepData{}, // no pre-existing components
+		Steps: map[string]Step{
+			"builds": {Status: StepStatusPending},
+		},
+	}
+
+	// stepName is the alias "build"; aggregateStepName is the canonical "builds".
+	overlayComponentState(slip, "build", "builds", "api", StepStatusCompleted, insertedAt)
+
+	// The component must live under the canonical key "builds".
+	comps, ok := slip.Aggregates["builds"]
+	if !ok || len(comps) == 0 {
+		t.Fatalf("T2 regression: expected component under canonical key \"builds\", got Aggregates=%v", slip.Aggregates)
+	}
+
+	found := false
+	for _, c := range comps {
+		if c.Component == "api" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf(
+			"T2 regression: component \"api\" not found under canonical key \"builds\", Aggregates=%v",
+			slip.Aggregates,
+		)
+	}
+
+	// Must NOT appear under the alias key "build" — that would be the pre-fix behaviour.
+	if aliasComps := slip.Aggregates["build"]; len(aliasComps) > 0 {
+		t.Errorf("T2 regression: component unexpectedly stored under alias key \"build\"; should be under \"builds\"")
 	}
 }

--- a/slippy/executor_test.go
+++ b/slippy/executor_test.go
@@ -1076,7 +1076,13 @@ func TestUpdateStepWithStatus_PipelineCompletion(t *testing.T) {
 		}
 		store.AddSlip(slip)
 
-		if err := client.FailStep(ctx, "corr-pcfail-2", "builds", "mc.invoice.api", "component build failed"); err != nil {
+		if err := client.FailStep(
+			ctx,
+			"corr-pcfail-2",
+			"builds",
+			"mc.invoice.api",
+			"component build failed",
+		); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 

--- a/slippy/mock_store_test.go
+++ b/slippy/mock_store_test.go
@@ -86,36 +86,36 @@ type MockStore struct {
 	CommitIndex map[string]string
 
 	// Call tracking
-	CreateCalls            []CreateCall
-	LoadCalls              []string
-	LoadByCommitCalls      []LoadByCommitCall
-	FindByCommitsCalls     []FindByCommitsCall
-	FindAllByCommitsCalls  []FindAllByCommitsCall
-	UpdateCalls            []UpdateCall
-	UpdateStepCalls        []UpdateStepCall
-	UpdateComponentCalls   []UpdateComponentCall
-	AppendHistoryCalls     []AppendHistoryCall
-	SetImageTagCalls       []SetImageTagCall
-	UpdateSlipStatusCalls  []UpdateSlipStatusCall
-	CloseCalls             int
+	CreateCalls           []CreateCall
+	LoadCalls             []string
+	LoadByCommitCalls     []LoadByCommitCall
+	FindByCommitsCalls    []FindByCommitsCall
+	FindAllByCommitsCalls []FindAllByCommitsCall
+	UpdateCalls           []UpdateCall
+	UpdateStepCalls       []UpdateStepCall
+	UpdateComponentCalls  []UpdateComponentCall
+	AppendHistoryCalls    []AppendHistoryCall
+	SetImageTagCalls      []SetImageTagCall
+	UpdateSlipStatusCalls []UpdateSlipStatusCall
+	CloseCalls            int
 
 	// Ping tracking and error injection
 	PingCalls int
 	PingError error
 
 	// Error injection for testing error paths
-	CreateError            error
-	LoadError              error
-	LoadByCommitError      error
-	FindByCommitsError     error
-	FindAllByCommitsError  error
-	UpdateError            error
-	UpdateStepError        error
-	UpdateComponentError   error
-	AppendHistoryError     error
-	SetImageTagError       error
-	UpdateSlipStatusError  error
-	CloseError             error
+	CreateError           error
+	LoadError             error
+	LoadByCommitError     error
+	FindByCommitsError    error
+	FindAllByCommitsError error
+	UpdateError           error
+	UpdateStepError       error
+	UpdateComponentError  error
+	AppendHistoryError    error
+	SetImageTagError      error
+	UpdateSlipStatusError error
+	CloseError            error
 
 	// Conditional error injection (returns error only for specific IDs)
 	CreateErrorFor          map[string]error

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -1967,7 +1967,14 @@ func TestClient_PromoteSlip_Immutable(t *testing.T) {
 		}
 		store.AddSlip(slip)
 
-		if err := client.UpdateStepWithStatus(ctx, "corr-promoted-update", "builds", "", StepStatusFailed, "late build failure"); err != nil {
+		if err := client.UpdateStepWithStatus(
+			ctx,
+			"corr-promoted-update",
+			"builds",
+			"",
+			StepStatusFailed,
+			"late build failure",
+		); err != nil {
 			t.Fatalf("UpdateStepWithStatus returned unexpected error: %v", err)
 		}
 
@@ -2106,7 +2113,14 @@ func TestClient_AbandonSlip_Immutable(t *testing.T) {
 		}
 		store.AddSlip(slip)
 
-		if err := client.UpdateStepWithStatus(ctx, "corr-abandoned-update", "builds", "", StepStatusFailed, "late build failure"); err != nil {
+		if err := client.UpdateStepWithStatus(
+			ctx,
+			"corr-abandoned-update",
+			"builds",
+			"",
+			StepStatusFailed,
+			"late build failure",
+		); err != nil {
 			t.Fatalf("UpdateStepWithStatus returned unexpected error: %v", err)
 		}
 

--- a/slippy/state_machine_invariants_test.go
+++ b/slippy/state_machine_invariants_test.go
@@ -614,12 +614,15 @@ func TestStateMachine_I5_AtomicStatusUpdateRespectsStepOverride(t *testing.T) {
 // TestE2E_ConcurrentTerminalStepEvents_RoutingSlipsMatchesEventLog (integration tag).
 //
 // Precondition: slip=in_progress, prod_alert_gate=running, prod_rollback=running,
-//               prod_steady_state=running
+//
+//	prod_steady_state=running
+//
 // Actions (sequential):
-//   1. FailStep(prod_alert_gate)     → slip=failed, one primary failure
-//   2. CompleteStep(prod_rollback)   → checkPipelineCompletion re-runs; prod_alert_gate
-//                                      still a primary failure, must remain in overrides
-//   3. FailStep(prod_steady_state)   → second primary failure added
+//  1. FailStep(prod_alert_gate)     → slip=failed, one primary failure
+//  2. CompleteStep(prod_rollback)   → checkPipelineCompletion re-runs; prod_alert_gate
+//     still a primary failure, must remain in overrides
+//  3. FailStep(prod_steady_state)   → second primary failure added
+//
 // Expected after all three actions:
 //   - slip.status == failed
 //   - prod_alert_gate.status == failed


### PR DESCRIPTION
## Summary

Adds a read-your-own-writes overlay to the slip aggregate write path. Closes an async-insert race where `insertComponentState`'s ClickHouse INSERT was not visible to the immediately-subsequent `loadComponentStates` SELECT, causing `routing_slips.<step>_status` to be permanently stuck at `running` even after all components finished.

Confirmed in prod on slips:
- `d15f1808-5727-4df4-83d8-c526afd2c79e` (MC.Invoice)
- `51a2cb11-960b-4974-b131-2d85513cb4ba` (MC.Invoice)

## Root cause

`UpdateStepWithHistory` flow (`clickhouse_store.go:78`):

```
insertComponentState(...)                                      // async INSERT
  → updateAggregateStatusFromComponentStatesWithHistory(...)
       → s.Load(...) → hydrateSlip → loadComponentStates(...)  // SELECT misses fresh row
       → computeAggregateStatus(...) → returns stale "running"
       → s.Update(routing_slips, builds_status=running)        // wrong write
```

Both ops share a single `driver.Conn` with no transaction. ClickHouse `async_insert=1` means INSERT returns OK before the row is visible to subsequent SELECTs on the same connection (~200ms flush window). `computeAggregateStatus` reads pre-insert state, `Update()` writes it, version check passes (no concurrent writer) → no retry fixes it. ReplacingMergeTree eventually merges the row but `routing_slips` write-back never re-fires.

## Fix (3 commits, review-driven)

### Commit 1 `1981532` — Initial overlay

`overlayComponentState` — pure Go function. After `insertComponentState`, merges the just-written component into the in-memory `slip.Aggregates[aggregateStepName]` slice before `computeAggregateStatus`. Zero ClickHouse overhead, preserves async-insert throughput.

### Commit 2 `97c408f` — Round-1 review corrections (CRITICAL)

PR review round 1 found the initial fix was **mechanically incomplete**:

- **T1 (CRITICAL)**: `Update()` → `BuildStepColumnsAndValues` reads `slip.Steps[step].Status` for the scalar `{step}_status` Enum8 column. Overlay only patched `slip.Aggregates`, never `slip.Steps`. So `builds_status` would stay `running` despite correct aggregate JSON. **Fix:** after `overlayComponentState`, recompute aggregate from `slip.Aggregates[aggregateStepName]` and apply to `slip.Steps[aggregateStepName]` via `ApplyStatusTransition`. Applied in both `updateAggregateStatusFromComponentStates` and `updateAggregateStatusFromComponentStatesWithHistory`.

- **T2 (CRITICAL)**: New-component append path used raw `stepName` (could be alias `"build"`) instead of canonical aggregate key (`"builds"`). `BuildAggregateColumnsAndValues` only reads canonical key. **Fix:** `overlayComponentState` signature now accepts `aggregateStepName`. Both callers resolve and pass it.

- **T3 (IMPORTANT)**: Original regression test asserted only on `slip.Aggregates` slice, missed `slip.Steps` divergence. **Fix:** added `TestOverlayUpdatesStepsStatus_T1Regression` asserting `slip.Steps["builds"].Status == completed` post-overlay + `TestOverlayNewComponentUnderCanonicalKey_T2Regression` for T2 path.

- **T4, T5 (SUGGESTION)**: Documentation gaps on `latestComponentTime` zero-time semantics and `insertedAt` clock-skew safety on retry. **Fix:** doc comments added.

### Commit 3 (round-2 polish, on this branch)

PR review round 2 verified all round-1 fixes correct and complete. 3 new suggestions:

- **N1 (SUGGESTION)**: `overlayComponentState` doc-comment described an unreachable `""` fallback path that would have reintroduced T2 bug if a future caller hit it. **Fix:** removed misleading doc line, added defensive guard `if aggregateStepName == "" { return }` on the component-overlay path, simplified dead `bucketKey` fallback.

- **N2 (SUGGESTION)**: Recompute block passes all components (incl. pending placeholders) to `computeAggregateStatus`, while `applyComponentStatesToAggregate` filters to active-only. Same function returns different results depending on call site. Pre-existing divergence, neutral in current scenario. **Fix:** comment added above both recompute blocks documenting the divergence + tracking alignment as separate follow-up.

- **N3 (SUGGESTION)**: Skipped — regression test inline mirror is intentional, integration coverage exists.

## Spec alignment (STATE_MACHINE_V3.md)

| Invariant | Impact |
|---|---|
| I1 (aggregate from event log) | Preserved — overlay IS the just-appended event |
| Append-only events | Preserved |
| Terminal-success monotonic | Preserved |
| **I5** (cached column == event-log-derived) | **Strengthened** — eliminates permanent stale window. External CH readers retain bounded ~200ms staleness during async flush (unchanged); fix eliminates permanent staleness from write-back path. |
| Single authoritative write per terminal event | Preserved |

`.github/STATE_MACHINE_V3.md` updated with I5 overlay mechanism note. `.github/PROJECT_STATE.md` updated with full fix entry under "Recent Changes — May 13, 2026".

## Why this approach (Option 3 — in-memory overlay)

| Option | Approach | Trade-off |
|---|---|---|
| 1 — `SETTINGS wait_for_async_insert=1` | Sync flush before INSERT returns | Adds per-insert latency, drops async throughput |
| 2 — Retry/poll loop in `updateAggregateStatus*` | Re-query SELECT until row visible | Amplifies CH read load, stacks with CLI retries |
| 3 — Overlay (this PR) | Merge in Go memory | Zero CH overhead, deterministic, uses data already in hand |

Writer already constructs the row it just inserted — merging into in-memory Slip before `Update()` is free and deterministic.

## Cache layer note

`slippy-api/internal/infrastructure/cache.go` is **passthrough stub** today. `CachedSlipReader.{Load, LoadByCommit, FindByCommits, FindAllByCommits, InvalidateByCorrelationID}` all delegate without caching. Redis/Dragonfly client wired but GET/SET not implemented; Helm/K8s manifests not deployed; `DRAGONFLY_HOST` empty everywhere.

**This PR does not touch the cache layer.** When the cache activates (separate PR), write path's `invalidate` (called at `slippy-api/slip_write_handler.go:364`) must:

1. DELETE cached slip entry by correlation_id for `Load` keys
2. DELETE any cached `by-commit` keys that map to this correlation_id
3. DELETE cached `find-by-commits` / `find-all-by-commits` result sets containing this correlation_id

Without this, cache hits would return stale `routing_slips` values from before the overlay write. **Tracked as separate follow-up.**

## Test plan

```
TestOverlayComponentState_AddsNewComponent                       PASS
TestOverlayComponentState_ReplacesOlderEntry                     PASS
TestOverlayComponentState_LeavesNewerEntryAlone                  PASS
TestOverlayComponentState_OnlyTouchesNamedComponent              PASS
TestOverlayComponentState_NilSlip                                PASS
TestOverlayComponentState_PipelineLevelStep                      PASS
TestUpdateAggregateStatusFromComponentStates_AsyncInsertRace     PASS  ← original regression
TestOverlayUpdatesStepsStatus_T1Regression                       PASS  ← T1 regression
TestOverlayNewComponentUnderCanonicalKey_T2Regression            PASS  ← T2 regression
```

**Gates:**

| Gate | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `gofmt -l .` | Clean |
| `go test ./... -race -count=1 -timeout=3m` | PASS (slippy 3.7s, slippytest 1.7s) |

**Coverage:** package overall 83.3%; `overlayComponentState` 96.7%; `latestComponentTime` 100%; `updateAggregateStatusFromComponentStates` 88.9%; `updateAggregateStatusFromComponentStatesWithHistory` 81.7%.

## Risk

**Low.** Scoped to two private functions. No schema change. No change to `insertComponentState`, ClickHouse settings, or `conflictVersion` retry path. Behavior change is strictly additive: newer overlay wins, older skipped, missing component added under canonical key.

External CH readers (HyperDX dashboards, ad-hoc queries) retain existing bounded async-flush staleness — unchanged. Fix only eliminates permanent stale state from write-back.

## Rollback

Revert. No DB migration. No infrastructure changes.

## Follow-ups (separate PRs)

1. **Cache invalidation** — when Dragonfly cache activates, implement `invalidate` for write path in `slippy-api/infrastructure/cache.go` (see Cache layer note).
2. **Gap B — crash recovery** — if slippy-api crashes between `insertComponentState` and routing_slips Update, no mechanism re-fires aggregate. WAL or periodic reconciler needed.
3. **Stuck-slip backfill** — `d15f1808`, `51a2cb11`, plus any others stuck before this fix lands need manual remediation. CollapsingMergeTree requires `-1` cancel + `+1` corrected pair.
4. **Placeholder-divergence alignment** — `computeAggregateStatus` filtering paths differ between `applyComponentStatesToAggregate` (active-only) and recompute block (all incl. placeholders). Neutral in current scenario; alignment worth doing.
5. **Component alias double-entry (cosmetic)** — closed by N1 guard; future callers must resolve aggregate key before invoking overlay.

## Review trail

- Round 1: 5 findings (2 critical, 1 important, 2 suggestions) — all resolved in commit `97c408f`
- Round 2: 3 suggestions — N1 + N2 applied in round-2 polish commit; N3 dismissed per devils-advocate verdict
- Security: 0 findings across both rounds (no auth, no SQL changes, no new imports, no secrets in test data)
