### PR TITLE
fix(github): JWT exp margin for GitHub App auth

### DIFF
--- a/github/graphql.go
+++ b/github/graphql.go
@@ -497,10 +497,15 @@ func parseNextPageURL(linkHeader string) string {
 
 // generateAppJWT creates a JWT for authenticating as the GitHub App.
 func (g *GraphQLClient) generateAppJWT() (string, error) {
+	// JWT timing chosen to survive clock drift between this host and GitHub:
+	//   - iat backdated 60s so a host clock running ahead of GitHub never
+	//     produces an iat in GitHub's future
+	//   - exp set so (exp - iat) is strictly less than GitHub's 600s ceiling
+	//     ("Expiration time' claim ('exp') is too far in the future")
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"iat": now.Unix(),
-		"exp": now.Add(10 * time.Minute).Unix(),
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(9*time.Minute - time.Second).Unix(),
 		"iss": g.appID,
 	}
 

--- a/github/graphql.go
+++ b/github/graphql.go
@@ -18,6 +18,20 @@ import (
 	"github.com/MyCarrier-DevOps/goLibMyCarrier/logger"
 )
 
+// GitHub App JWT timing parameters. See:
+// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
+//
+// GitHub's hard ceiling: exp - iat <= 600s, measured against GitHub's clock.
+// ghAppJWTBackdate shifts iat into the past to tolerate the issuing host's
+// clock leading GitHub's clock; ghAppJWTLifetime keeps exp - iat strictly
+// under 600s. The 60s backdating is the dominant skew-tolerance term:
+// widening lifetime beyond ~540s does not increase tolerance because the
+// iat-not-in-future check caps it at the backdate value.
+const (
+	ghAppJWTBackdate = 60 * time.Second
+	ghAppJWTLifetime = 599 * time.Second
+)
+
 // GraphQLConfig holds GitHub GraphQL API authentication configuration.
 // It supports automatic installation discovery per organization.
 type GraphQLConfig struct {
@@ -497,15 +511,15 @@ func parseNextPageURL(linkHeader string) string {
 
 // generateAppJWT creates a JWT for authenticating as the GitHub App.
 func (g *GraphQLClient) generateAppJWT() (string, error) {
-	// JWT timing chosen to survive clock drift between this host and GitHub:
-	//   - iat backdated 60s so a host clock running ahead of GitHub never
-	//     produces an iat in GitHub's future
-	//   - exp set so (exp - iat) is strictly less than GitHub's 600s ceiling
-	//     ("Expiration time' claim ('exp') is too far in the future")
-	now := time.Now()
+	// Snapshot and truncate to whole seconds so sub-second jitter cannot
+	// push exp-iat across GitHub's 600s ceiling. Derive exp from iat (not
+	// from now) so the spec invariant (exp - iat < 600s) is structural, not
+	// arithmetic-dependent.
+	iat := time.Now().Add(-ghAppJWTBackdate).Truncate(time.Second)
+	exp := iat.Add(ghAppJWTLifetime)
 	claims := jwt.MapClaims{
-		"iat": now.Add(-60 * time.Second).Unix(),
-		"exp": now.Add(9*time.Minute - time.Second).Unix(),
+		"iat": iat.Unix(),
+		"exp": exp.Unix(),
 		"iss": g.appID,
 	}
 

--- a/github/graphql_test.go
+++ b/github/graphql_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -876,6 +877,38 @@ func TestGenerateAppJWT(t *testing.T) {
 	assert.NotEmpty(t, token)
 	// JWT tokens have 3 parts separated by dots
 	assert.Regexp(t, `^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`, token)
+}
+
+func TestGenerateAppJWT_ClockSkewMargin(t *testing.T) {
+	privateKey := testPrivateKey(t)
+
+	client, err := NewGraphQLClient(GraphQLConfig{
+		AppID:      12345,
+		PrivateKey: privateKey,
+	}, nil)
+	require.NoError(t, err)
+
+	tokenStr, err := client.generateAppJWT()
+	require.NoError(t, err)
+
+	parsed, _, err := new(jwt.Parser).ParseUnverified(tokenStr, jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims := parsed.Claims.(jwt.MapClaims)
+	iat := int64(claims["iat"].(float64))
+	exp := int64(claims["exp"].(float64))
+	now := time.Now().Unix()
+
+	// iat backdated to tolerate slippy-api host leading GitHub clock
+	assert.LessOrEqual(t, iat, now, "iat must not be in the future")
+	assert.GreaterOrEqual(t, iat, now-120, "iat backdating should be ~60s, allow jitter")
+
+	// exp-iat strictly under GitHub's 600s ceiling
+	assert.Less(t, exp-iat, int64(600), "exp-iat must be < 600s per GitHub spec")
+	assert.GreaterOrEqual(t, exp-iat, int64(480), "exp-iat must remain useful (>=8min)")
+
+	// exp future-dated
+	assert.Greater(t, exp, now, "exp must be future-dated")
 }
 
 // ---- Edge Cases ----

--- a/github/graphql_test.go
+++ b/github/graphql_test.go
@@ -909,6 +909,22 @@ func TestGenerateAppJWT_ClockSkewMargin(t *testing.T) {
 
 	// exp future-dated
 	assert.Greater(t, exp, now, "exp must be future-dated")
+
+	// GitHub's actual server-side check is against its own wall clock at
+	// receive time. Assert the invariant from now's perspective too — guards
+	// against a regression where iat backdating is removed but exp is unchanged.
+	assert.LessOrEqual(t, exp-now, int64(600), "exp must be within 600s of wall-clock now (the actual GitHub check)")
+	assert.Greater(t, exp, iat, "exp must be after iat")
+
+	// Regression guard: iss claim must be appID
+	iss, ok := claims["iss"]
+	require.True(t, ok, "iss claim must be present")
+	// jwt.MapClaims encodes int64 as float64 via JSON
+	assert.Equal(t, float64(12345), iss, "iss must match configured appID")
+
+	// Regression guard: signing alg must be RS256 (GitHub requires asymmetric)
+	require.NotNil(t, parsed.Header, "JWT header must be present")
+	assert.Equal(t, "RS256", parsed.Header["alg"], "alg must be RS256")
 }
 
 // ---- Edge Cases ----


### PR DESCRIPTION
## Summary
- Pin JWT `iat = now - 60s`, `exp = now + 9min - 1s` (was `iat=now`, `exp=now+10min` exactly)
- Add regression test asserting `exp - iat < 600s` and `iat <= now`

## Why
GitHub rejects JWTs where `exp` is more than 10 minutes ahead of its clock.
Zero-margin code amplified small clock drift into 401 bursts (120/hr peak
2026-05-12 21:00-01:00 UTC). Caused slip creation to fall into ancestry
fail-open path, silently weakening CI gating.

Spec: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app

Note: the `-1s` on `exp` keeps `(exp - iat)` strictly less than the 600s
ceiling (otherwise integer-second arithmetic would land exactly on 600).

## Test plan
- [x] `make fmt`
- [x] `make lint PKG=github` (0 issues)
- [x] `make test PKG=github` (ok, coverage 83.7%)
- [x] `make check-sec PKG=github` (no vulnerabilities)
- [ ] `make check-coverage` skipped — broken on `main` (missing `.testcoverage.yml`, unresolved `${GOBIN}` in Makefile). Pre-existing and unrelated to this change.
- [x] New unit test `TestGenerateAppJWT_ClockSkewMargin` asserts invariants
- [ ] Consumer `slippy-api` bumped to new tag in follow-up PR (Phase 2)
- [ ] Post-deploy HyperDX `ServiceName:MyCarrierPipeline AND Body:Expiration` returns zero

bd: mycarrier-cor