### PR TITLE
feat(repocanon): add ArgoCDAppNames for dual L1+L2 deterministic naming

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ SHELL:=/bin/bash
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-LIB_DIRS := argocdclient auth cievents clickhouse clickhousemigrator github kafka logger otel pollyapi slippy slippyapi vault yaml
+LIB_DIRS := argocdclient auth cievents clickhouse clickhousemigrator github kafka logger otel pollyapi repocanon slippy slippyapi vault yaml
 
 .PHONY: lint
 lint: install-tools

--- a/repocanon/repocanon.go
+++ b/repocanon/repocanon.go
@@ -110,6 +110,71 @@ func FromRaw(raw string) Names {
 	}
 }
 
+// MetaEnvFor maps a deploy environment to its gitops "metaEnv" bucket.
+// Returns "prod" when env == "prod", otherwise "dev". The gitops repo
+// layout uses Apps/<metaEnv>-<appstack>/ for child paths.
+//
+// Input is lowercased and whitespace-trimmed before comparison.
+func MetaEnvFor(environment string) string {
+	if strings.ToLower(strings.TrimSpace(environment)) == "prod" {
+		return "prod"
+	}
+	return "dev"
+}
+
+// ClusterFor maps a gitops metaEnv to the ArgoCD cluster name (from Vault
+// clusterSecrets/<env>.name). "prod" -> "production-csp"; "dev" -> "development".
+// Falls back to "development" for unknown metaEnvs (matches the cluster
+// generator's non-prod default).
+//
+// Input is lowercased and whitespace-trimmed before comparison.
+func ClusterFor(metaEnv string) string {
+	if strings.ToLower(strings.TrimSpace(metaEnv)) == "prod" {
+		return "production-csp"
+	}
+	return "development"
+}
+
+// ArgoCDAppNames returns the deterministic ArgoCD app names for both layers:
+//
+//	l1 — gitops-watcher Application, always present
+//	     format: "<cluster>-<metaEnv>-<appStack>" (matches the per-cluster
+//	     bootstrap ApplicationSet template at
+//	     ManagementInfra/Apps/app-cluster-gitops/app-cluster-bootstrapper.yaml).
+//	l2 — chart-sourced workload Application, only for chart types that emit one
+//	     mc-environment chart       -> "<appStack>-<environment>"
+//	     mycarrier-helm + feature*  -> "<appStack>-offload-<environment>"  (offload)
+//	     otherwise                  -> "", hasL2=false
+//
+// appStack must be the value rendered from helm values' global.appStack
+// (callers supply explicitly; it can differ from Names.Service in rare
+// cases — e.g. MC.Frontend.Domains uses "frontend.domains").
+//
+// environment and chartType are lowercased + whitespace-trimmed for routing;
+// appStack is preserved verbatim. Empty appStack yields names with empty
+// segments — callers should validate non-empty before invoking.
+func (n Names) ArgoCDAppNames(environment, chartType, appStack string) (l1, l2 string, hasL2 bool) {
+	env := strings.ToLower(strings.TrimSpace(environment))
+	chart := strings.ToLower(strings.TrimSpace(chartType))
+
+	metaEnv := MetaEnvFor(env)
+	cluster := ClusterFor(metaEnv)
+	l1 = cluster + "-" + metaEnv + "-" + appStack
+
+	switch {
+	case chart == "mc-environment":
+		l2 = appStack + "-" + env
+		hasL2 = true
+	case strings.HasPrefix(env, "feature"):
+		l2 = appStack + "-offload-" + env
+		hasL2 = true
+	default:
+		l2 = ""
+		hasL2 = false
+	}
+	return l1, l2, hasL2
+}
+
 // ArgoCDAppName composes the canonical ArgoCD application name from the
 // canonical Service plus the deploy environment and chart-type. Rules
 // match workflow-core/workflows/templates/render-deploy-core.yaml:

--- a/repocanon/repocanon.go
+++ b/repocanon/repocanon.go
@@ -151,9 +151,13 @@ func ClusterFor(metaEnv string) string {
 // cases — e.g. MC.Frontend.Domains uses "frontend.domains").
 //
 // environment and chartType are lowercased + whitespace-trimmed for routing;
-// appStack is preserved verbatim. Empty appStack yields names with empty
-// segments — callers should validate non-empty before invoking.
+// appStack is preserved verbatim. Empty appStack short-circuits to
+// ("", "", false) — we refuse to emit names with trailing/empty segments
+// (e.g. "development-dev-") that ArgoCD/Kubernetes would reject anyway.
 func (n Names) ArgoCDAppNames(environment, chartType, appStack string) (l1, l2 string, hasL2 bool) {
+	if appStack == "" {
+		return "", "", false
+	}
 	env := strings.ToLower(strings.TrimSpace(environment))
 	chart := strings.ToLower(strings.TrimSpace(chartType))
 

--- a/repocanon/repocanon_test.go
+++ b/repocanon/repocanon_test.go
@@ -422,6 +422,153 @@ func TestArgoCDAppName(t *testing.T) {
 	}
 }
 
+// TestMetaEnvFor pins the prod/dev bucket routing used by gitops layout.
+func TestMetaEnvFor(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "prod", env: "prod", want: "prod"},
+		{name: "dev", env: "dev", want: "dev"},
+		{name: "preprod", env: "preprod", want: "dev"},
+		{name: "feature17", env: "feature17", want: "dev"},
+		{name: "empty", env: "", want: "dev"},
+		{name: "mixed-case PROD", env: "PROD", want: "prod"},
+		{name: "whitespace prod", env: "  prod  ", want: "prod"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MetaEnvFor(tt.env); got != tt.want {
+				t.Errorf("MetaEnvFor(%q) = %q, want %q", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClusterFor pins the metaEnv -> ArgoCD cluster name mapping (matches
+// Vault clusterSecrets/<env>.name).
+func TestClusterFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		metaEnv string
+		want    string
+	}{
+		{name: "prod", metaEnv: "prod", want: "production-csp"},
+		{name: "dev", metaEnv: "dev", want: "development"},
+		{name: "preprod (non-prod default)", metaEnv: "preprod", want: "development"},
+		{name: "unknown falls back to development", metaEnv: "wat", want: "development"},
+		{name: "empty falls back to development", metaEnv: "", want: "development"},
+		{name: "mixed-case PROD", metaEnv: "PROD", want: "production-csp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClusterFor(tt.metaEnv); got != tt.want {
+				t.Errorf("ClusterFor(%q) = %q, want %q", tt.metaEnv, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestArgoCDAppNames pins the dual-layer L1 (gitops-watcher) + L2
+// (chart-sourced workload) ArgoCD app-name derivation. L1 is always
+// "<cluster>-<metaEnv>-<appStack>"; L2 only exists for mc-environment
+// charts and for mycarrier-helm offload feature envs.
+func TestArgoCDAppNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       string
+		chartType string
+		appStack  string
+		wantL1    string
+		wantL2    string
+		wantHasL2 bool
+	}{
+		{
+			name:      "mc-environment + prod + mycarrier",
+			env:       "prod",
+			chartType: "mc-environment",
+			appStack:  "mycarrier",
+			wantL1:    "production-csp-prod-mycarrier",
+			wantL2:    "mycarrier-prod",
+			wantHasL2: true,
+		},
+		{
+			name:      "mc-environment + feature17 + mycarrier",
+			env:       "feature17",
+			chartType: "mc-environment",
+			appStack:  "mycarrier",
+			wantL1:    "development-dev-mycarrier",
+			wantL2:    "mycarrier-feature17",
+			wantHasL2: true,
+		},
+		{
+			name:      "mc-environment + dev + mycarrier",
+			env:       "dev",
+			chartType: "mc-environment",
+			appStack:  "mycarrier",
+			wantL1:    "development-dev-mycarrier",
+			wantL2:    "mycarrier-dev",
+			wantHasL2: true,
+		},
+		{
+			name:      "mycarrier-helm + prod + quote (no L2)",
+			env:       "prod",
+			chartType: "mycarrier-helm",
+			appStack:  "quote",
+			wantL1:    "production-csp-prod-quote",
+			wantL2:    "",
+			wantHasL2: false,
+		},
+		{
+			name:      "mycarrier-helm + dev + quote (no L2)",
+			env:       "dev",
+			chartType: "mycarrier-helm",
+			appStack:  "quote",
+			wantL1:    "development-dev-quote",
+			wantL2:    "",
+			wantHasL2: false,
+		},
+		{
+			name:      "mycarrier-helm + feature13 + quote (offload)",
+			env:       "feature13",
+			chartType: "mycarrier-helm",
+			appStack:  "quote",
+			wantL1:    "development-dev-quote",
+			wantL2:    "quote-offload-feature13",
+			wantHasL2: true,
+		},
+		{
+			name:      "appStack divergence: frontend.domains used literally in L1",
+			env:       "dev",
+			chartType: "mc-environment",
+			appStack:  "frontend.domains",
+			wantL1:    "development-dev-frontend.domains",
+			wantL2:    "frontend.domains-dev",
+			wantHasL2: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Names.Service is intentionally divergent from appStack here to
+			// prove ArgoCDAppNames uses the explicit appStack param, not
+			// n.Service.
+			n := Names{Service: "frontend-domains"}
+			l1, l2, hasL2 := n.ArgoCDAppNames(tt.env, tt.chartType, tt.appStack)
+			if l1 != tt.wantL1 {
+				t.Errorf("L1 = %q, want %q", l1, tt.wantL1)
+			}
+			if l2 != tt.wantL2 {
+				t.Errorf("L2 = %q, want %q", l2, tt.wantL2)
+			}
+			if hasL2 != tt.wantHasL2 {
+				t.Errorf("hasL2 = %v, want %v", hasL2, tt.wantHasL2)
+			}
+		})
+	}
+}
+
 func BenchmarkFromRaw(b *testing.B) {
 	// Hot path: the most common input shape (full GitHub repo name from
 	// webhook events).

--- a/repocanon/repocanon_test.go
+++ b/repocanon/repocanon_test.go
@@ -547,6 +547,41 @@ func TestArgoCDAppNames(t *testing.T) {
 			wantL2:    "frontend.domains-dev",
 			wantHasL2: true,
 		},
+		{
+			// Mixed-case env is lowercased + trimmed before routing, so PROD
+			// normalizes through metaEnv=prod -> cluster=production-csp and
+			// the L2 suffix is also lowercased. Parity with TestArgoCDAppName.
+			name:      "mixed-case PROD normalizes to prod",
+			env:       "PROD",
+			chartType: "mc-environment",
+			appStack:  "mycarrier",
+			wantL1:    "production-csp-prod-mycarrier",
+			wantL2:    "mycarrier-prod",
+			wantHasL2: true,
+		},
+		{
+			// appStack is preserved verbatim (NOT trimmed), unlike env/chartType.
+			// Pinning the current contract: leading/trailing whitespace in
+			// appStack leaks into the rendered names. Callers must pre-trim.
+			name:      "whitespace in appStack preserved verbatim",
+			env:       "dev",
+			chartType: "mc-environment",
+			appStack:  "  mycarrier  ",
+			wantL1:    "development-dev-  mycarrier  ",
+			wantL2:    "  mycarrier  -dev",
+			wantHasL2: true,
+		},
+		{
+			// G3 guard: empty appStack short-circuits to ("", "", false)
+			// instead of emitting invalid trailing-dash names.
+			name:      "empty appStack returns empty + hasL2=false",
+			env:       "dev",
+			chartType: "mc-environment",
+			appStack:  "",
+			wantL1:    "",
+			wantL2:    "",
+			wantHasL2: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Adds `MetaEnvFor`, `ClusterFor`, and `Names.ArgoCDAppNames` helpers so callers can derive both layers of MyCarrier's ArgoCD application topology from `(environment, chartType, appStack)` without ad-hoc shell logic:

- **L1** — gitops-watcher app (always present): `<cluster>-<metaEnv>-<appStack>` (matches the per-cluster bootstrap ApplicationSet).
- **L2** — chart-sourced workload app: `<appStack>-<env>` for mc-environment; `<appStack>-offload-<env>` for mycarrier-helm + `feature*` env (offload); none otherwise.

Existing `ArgoCDAppName` preserved unchanged for back-compat.

Also `chore(repocanon)` — adds `repocanon` to `LIB_DIRS` in the repo `makefile` so `make lint` / `make test` / `make check-sec` exercise the module under CI gates (it was previously silently skipped). Guards `ArgoCDAppNames` against empty `appStack` (returns `"", "", false`).

## Why
Required by deploy-reporter dual-stage verification. Single naming source so workflow templates carry zero shell logic for app-name derivation.

Symptom: prod release for MC.User (correlation 2be7aab7-79b6-45da-9e0d-af5d41dec735) — prod_steady_state failed with timeout. Watchdog said "prod_tests pending" for 20m, gave up at 16:52:17.
Real root cause in deploy-reporter binary:
  - deploy-reporter posted prod_deploy=done at 16:31:48 — first Phase-3 poll, ~24min before rollout was actually healthy.
  - IsSyncPending only checks per-resource health. ArgoCD 3.0+ resource-tree path hardcodes per-node syncStatus="Synced" (comparator.go:483).
  - Right after sync-start: new Rollout hasn't begun progressing, old pods still read Healthy → first poll sees nothing pending → premature success.
  - prod_steady_state's 20m watchdog anchored at premature 16:31:48 → timed out at 16:52:17, 4 min before rollout actually finished (16:56:10).
Merge order: #69 → tag → #21 (repoint go.mod) → image build → #59 (bump tag) → workflow-core mirror.

## Test plan
- [x] `go test ./...` — all subtests pass; `ArgoCDAppNames` 100% coverage; package 98%
- [x] `golangci-lint run` — 0 issues
- [x] `make lint` / `make test` / `make check-sec` now include repocanon

## Related PRs (cross-linked)
- MyCarrier-DevOps/deploy-reporter#21 — binary dual-stage verifier (consumes `ArgoCDAppNames`; will repoint go.mod to the tagged version after this merges)
- MyCarrier-DevOps/workflow-dev#59 — workflow passes the new dual-stage flags
