### PR TITLE
feat(slippy): add LoadLiveByCommit excluding superseded terminal statuses

### DIFF
--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -327,6 +327,16 @@ func (s *ClickHouseStore) LoadByCommit(ctx context.Context, repository, commitSH
 //   - Returns ErrSlipNotFound when no live slip exists.
 //   - For ancestry-aware lookups use FindByCommits / ResolveSlip instead.
 //
+// Why 'completed' is intentionally NOT in the NOT IN list: callers that need
+// to reject completed slips (e.g. the dedup-loser polling path that treats
+// completed as "race already finished, create fresh") must apply
+// SlipStatus.IsTerminal() at the caller level — see slip_writer.go's
+// awaitExistingSlip and push.go's CreateSlipForPush for the canonical pattern.
+// The query filters only the *superseded-terminal* subset because including
+// 'completed' here would cause callers using LoadLiveByCommit for status
+// reporting (build dashboards, deploy webhooks attaching to finished builds)
+// to get false ErrSlipNotFound responses for slips that successfully finished.
+//
 // VCMT collapse: the inner max(version) subquery picks the latest version per
 // correlation_id within the (repo, commit) scope before the status filter is
 // applied, so an abandoned latest version excludes the whole correlation rather
@@ -334,6 +344,12 @@ func (s *ClickHouseStore) LoadByCommit(ctx context.Context, repository, commitSH
 func (s *ClickHouseStore) LoadLiveByCommit(ctx context.Context, repository, commitSHA string) (*Slip, error) {
 	if s.pipelineConfig == nil {
 		return nil, fmt.Errorf("pipeline config is required for store operations")
+	}
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if commitSHA == "" {
+		return nil, fmt.Errorf("commit_sha is required")
 	}
 	query := s.queryBuilder.BuildSelectQuery(
 		fmt.Sprintf(

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -317,6 +317,47 @@ func (s *ClickHouseStore) LoadByCommit(ctx context.Context, repository, commitSH
 	return slip, nil
 }
 
+// LoadLiveByCommit looks up the most recent LIVE routing slip for (repository, commitSHA).
+//
+// Exclusion semantics:
+//   - Excludes superseded-terminal statuses: abandoned, promoted, compensated.
+//   - Does NOT exclude 'completed' — callers needing full SlipStatus.IsTerminal()
+//     semantics (which also treats completed as terminal) must keep their post-call
+//     guard.
+//   - Returns ErrSlipNotFound when no live slip exists.
+//   - For ancestry-aware lookups use FindByCommits / ResolveSlip instead.
+//
+// VCMT collapse: the inner max(version) subquery picks the latest version per
+// correlation_id within the (repo, commit) scope before the status filter is
+// applied, so an abandoned latest version excludes the whole correlation rather
+// than surfacing a stale earlier-version row.
+func (s *ClickHouseStore) LoadLiveByCommit(ctx context.Context, repository, commitSHA string) (*Slip, error) {
+	if s.pipelineConfig == nil {
+		return nil, fmt.Errorf("pipeline config is required for store operations")
+	}
+	query := s.queryBuilder.BuildSelectQuery(
+		fmt.Sprintf(
+			"WHERE lower(repository) = lower(?) AND commit_sha = ? AND sign = 1 "+
+				"AND (correlation_id, version) IN ("+
+				"  SELECT correlation_id, max(version) FROM %s.%s"+
+				"  WHERE lower(repository) = lower(?) AND commit_sha = ? AND sign = 1"+
+				"  GROUP BY correlation_id"+
+				") "+
+				"AND status NOT IN ('abandoned', 'promoted', 'compensated')",
+			s.database, TableRoutingSlips,
+		),
+		"ORDER BY version DESC LIMIT 1",
+	)
+	slip, err := s.scanSlip(ctx, query, repository, commitSHA, repository, commitSHA)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.hydrateSlip(ctx, slip); err != nil {
+		return nil, fmt.Errorf("failed to hydrate slip with component states: %w", err)
+	}
+	return slip, nil
+}
+
 // FindByCommits finds a slip matching any commit in the ordered list.
 // Returns the slip for the first (most recent) matching commit.
 func (s *ClickHouseStore) FindByCommits(

--- a/slippy/clickhouse_store_integration_test.go
+++ b/slippy/clickhouse_store_integration_test.go
@@ -4,6 +4,7 @@ package slippy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -1332,4 +1333,120 @@ func TestHydrateSlip_EmptyAggregates(t *testing.T) {
 	}
 
 	t.Log("SUCCESS: Hydration test complete")
+}
+
+// TestClickHouseStore_LoadLiveByCommit_VCMTCollapseExcludesAbandoned verifies that
+// LoadLiveByCommit applies its status filter BEFORE the ORDER BY/LIMIT post-collapse,
+// so a higher-version abandoned row does NOT mask a lower-version live in_progress row.
+//
+// This is the R7 integration assertion for the routing_slips
+// SharedVersionedCollapsingMergeTree engine: two sign=+1 rows for the same commit_sha
+// at different versions must be evaluated against the WHERE clause first; only then
+// does ORDER BY version DESC LIMIT 1 pick the winner.
+func TestClickHouseStore_LoadLiveByCommit_VCMTCollapseExcludesAbandoned(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	container, err := setupClickHouseContainer(ctx, t)
+	if err != nil {
+		t.Fatalf("failed to setup clickhouse container: %v", err)
+	}
+	defer func() {
+		if err := container.terminate(ctx); err != nil {
+			t.Logf("warning: failed to terminate container: %v", err)
+		}
+	}()
+
+	pipelineConfig := integrationTestPipelineConfig()
+	store, err := createTestStore(ctx, t, container, pipelineConfig)
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	defer store.Close()
+
+	commitSHA := fmt.Sprintf("live-by-commit-%d", time.Now().UnixNano())
+	repo := "myorg/livecommit-test"
+
+	// 1. Insert slip A — in_progress, lower version (created first).
+	corrA := fmt.Sprintf("corr-A-%d", time.Now().UnixNano())
+	slipA := createIntegrationTestSlip(corrA, []string{"api"}, pipelineConfig)
+	slipA.Repository = repo
+	slipA.CommitSHA = commitSHA
+	slipA.Status = SlipStatusInProgress
+	if err := store.Create(ctx, slipA); err != nil {
+		t.Fatalf("failed to create slip A: %v", err)
+	}
+
+	// 2. Insert slip B — different correlation_id, SAME commit_sha, in_progress.
+	//    Its Create call generates a HIGHER version (nextVersion is monotonic).
+	corrB := fmt.Sprintf("corr-B-%d", time.Now().UnixNano())
+	slipB := createIntegrationTestSlip(corrB, []string{"api"}, pipelineConfig)
+	slipB.Repository = repo
+	slipB.CommitSHA = commitSHA
+	slipB.Status = SlipStatusInProgress
+	if err := store.Create(ctx, slipB); err != nil {
+		// Schema may reject duplicate commit_sha across correlation_ids.
+		// Fall back: abandon corrA and assert LoadLiveByCommit returns ErrSlipNotFound.
+		// NOTE: The current routing_slips schema permits the dual-correlation insert at
+		// the same commit_sha (verified by this test passing in CI), so this fallback is
+		// purely defensive. If a future schema change rejects the dual insert, the R7
+		// VCMT collapse-vs-WHERE assertion below (steps 3-6) will be silently skipped;
+		// in that case, split this fallback into a dedicated
+		// TestClickHouseStore_LoadLiveByCommit_NoLiveAfterAbandon so the collapse
+		// assertion cannot be masked.
+		t.Logf("dual-correlation insert rejected (%v); falling back to single-correlation abandon path", err)
+		if err := store.UpdateSlipStatus(ctx, corrA, SlipStatusAbandoned); err != nil {
+			t.Fatalf("fallback: failed to abandon slip A: %v", err)
+		}
+		_, err := store.LoadLiveByCommit(ctx, repo, commitSHA)
+		if !errors.Is(err, ErrSlipNotFound) {
+			t.Errorf("fallback: expected ErrSlipNotFound after sole slip abandoned, got %v", err)
+		}
+		return
+	}
+
+	// 3. Abandon slip B — writes a higher-version sign=+1 row with status=abandoned.
+	if err := store.UpdateSlipStatus(ctx, corrB, SlipStatusAbandoned); err != nil {
+		t.Fatalf("failed to abandon slip B: %v", err)
+	}
+
+	// 4. LoadByCommit (existing buggy semantic) returns the abandoned slip
+	//    because ORDER BY version DESC LIMIT 1 wins post-collapse.
+	got, err := store.LoadByCommit(ctx, repo, commitSHA)
+	if err != nil {
+		t.Fatalf("LoadByCommit: %v", err)
+	}
+	if got.Status != SlipStatusAbandoned {
+		t.Errorf("LoadByCommit baseline: expected abandoned (highest version wins), got %s", got.Status)
+	}
+	if got.CorrelationID != corrB {
+		t.Errorf("LoadByCommit baseline: expected corrB %q, got %q", corrB, got.CorrelationID)
+	}
+
+	// 5. LoadLiveByCommit MUST return slip A (in_progress, lower version) — proving
+	//    the status filter is applied BEFORE the version-based collapse so the
+	//    abandoned higher-version row is excluded and the live row wins.
+	live, err := store.LoadLiveByCommit(ctx, repo, commitSHA)
+	if err != nil {
+		t.Fatalf("LoadLiveByCommit: %v", err)
+	}
+	if live.Status != SlipStatusInProgress {
+		t.Errorf("LoadLiveByCommit: expected in_progress, got %s", live.Status)
+	}
+	if live.CorrelationID != corrA {
+		t.Errorf("LoadLiveByCommit: expected corrA %q, got %q", corrA, live.CorrelationID)
+	}
+
+	// 6. Negative: if we also abandon A, LoadLiveByCommit must return ErrSlipNotFound.
+	if err := store.UpdateSlipStatus(ctx, corrA, SlipStatusAbandoned); err != nil {
+		t.Fatalf("failed to abandon slip A: %v", err)
+	}
+	_, err = store.LoadLiveByCommit(ctx, repo, commitSHA)
+	if !errors.Is(err, ErrSlipNotFound) {
+		t.Errorf("expected ErrSlipNotFound after all slips abandoned, got %v", err)
+	}
 }

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -1239,6 +1239,72 @@ func TestClickHouseStore_HydrateSlip_AllComponentStatesCompleted_AggregateComple
 	}
 }
 
+// TestClickHouseStore_LoadLiveByCommit tests the LoadLiveByCommit method.
+func TestClickHouseStore_LoadLiveByCommit(t *testing.T) {
+	t.Run("not found returns ErrSlipNotFound", func(t *testing.T) {
+		mockRow := &clickhousetest.MockRow{
+			ScanErr: ErrSlipNotFound,
+		}
+		mockSession := &clickhousetest.MockSession{
+			QueryRowRow: mockRow,
+		}
+		store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+		_, err := store.LoadLiveByCommit(context.Background(), "myorg/myrepo", "nonexistent")
+		if !errors.Is(err, ErrSlipNotFound) {
+			t.Errorf("expected ErrSlipNotFound, got %v", err)
+		}
+	})
+
+	t.Run("query contains status exclusion clause", func(t *testing.T) {
+		var capturedQuery string
+		mockSession := &clickhousetest.MockSession{
+			QueryRowFunc: func(_ context.Context, query string, _ ...any) driver.Row {
+				capturedQuery = query
+				return &clickhousetest.MockRow{ScanErr: ErrSlipNotFound}
+			},
+		}
+		store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+		_, _ = store.LoadLiveByCommit(context.Background(), "MyOrg/MyRepo", "abc123")
+
+		needles := []string{
+			"lower(repository)",
+			"sign = 1",
+			"status NOT IN ('abandoned', 'promoted', 'compensated')",
+			"max(version)",
+			"GROUP BY correlation_id",
+		}
+		for _, needle := range needles {
+			if !strings.Contains(capturedQuery, needle) {
+				t.Errorf("expected query to contain %q, got: %s", needle, capturedQuery)
+			}
+		}
+	})
+
+	t.Run("success returns slip", func(t *testing.T) {
+		mockRow := createMockScanRow("test-corr-002", "myorg/myrepo", "main", "abc123", SlipStatusInProgress)
+		mockSession := &clickhousetest.MockSession{
+			QueryRowRow: mockRow,
+			QueryWithArgsRows: &clickhousetest.MockRows{
+				CloseErr: nil,
+			},
+		}
+		store := NewClickHouseStoreFromSession(mockSession, testPipelineConfig(), "ci")
+
+		slip, err := store.LoadLiveByCommit(context.Background(), "myorg/myrepo", "abc123")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if slip == nil {
+			t.Fatal("expected slip to be non-nil")
+		}
+		if slip.CommitSHA != "abc123" {
+			t.Errorf("expected commit_sha 'abc123', got '%s'", slip.CommitSHA)
+		}
+	})
+}
+
 // TestClickHouseStore_LoadByCommit_Success tests successful slip loading by commit.
 func TestClickHouseStore_LoadByCommit_Success(t *testing.T) {
 	mockRow := createMockScanRow("test-corr-001", "myorg/myrepo", "main", "abc123", SlipStatusPending)

--- a/slippy/interfaces.go
+++ b/slippy/interfaces.go
@@ -26,6 +26,12 @@ type SlipStore interface {
 	// LoadByCommit retrieves a slip by repository and commit SHA
 	LoadByCommit(ctx context.Context, repository, commitSHA string) (*Slip, error)
 
+	// LoadLiveByCommit returns the LIVE (non-terminal) slip for the exact (repository, commitSHA).
+	// Excludes status in {abandoned, promoted, compensated}. Returns ErrSlipNotFound when no live
+	// slip exists. Use for in-flight dedup paths that require exact-SHA semantics. For
+	// ancestry-aware lookups use FindByCommits/ResolveSlip.
+	LoadLiveByCommit(ctx context.Context, repository, commitSHA string) (*Slip, error)
+
 	// FindByCommits finds a slip matching any commit in the ordered list.
 	// Returns the slip for the first (most recent) matching commit.
 	// The third return value is the matched commit SHA.

--- a/slippy/mock_store_test.go
+++ b/slippy/mock_store_test.go
@@ -89,6 +89,7 @@ type MockStore struct {
 	CreateCalls           []CreateCall
 	LoadCalls             []string
 	LoadByCommitCalls     []LoadByCommitCall
+	LoadLiveByCommitCalls []LoadByCommitCall
 	FindByCommitsCalls    []FindByCommitsCall
 	FindAllByCommitsCalls []FindAllByCommitsCall
 	UpdateCalls           []UpdateCall
@@ -107,6 +108,7 @@ type MockStore struct {
 	CreateError           error
 	LoadError             error
 	LoadByCommitError     error
+	LoadLiveByCommitError error
 	FindByCommitsError    error
 	FindAllByCommitsError error
 	UpdateError           error
@@ -269,6 +271,44 @@ func (m *MockStore) LoadByCommit(ctx context.Context, repository, commitSHA stri
 
 	slip, ok := m.Slips[correlationID]
 	if !ok {
+		return nil, ErrSlipNotFound
+	}
+
+	return deepCopySlip(slip), nil
+}
+
+// LoadLiveByCommit retrieves the most recent live slip by repository and commit SHA,
+// excluding superseded terminal statuses (abandoned, promoted, compensated).
+func (m *MockStore) LoadLiveByCommit(ctx context.Context, repository, commitSHA string) (*Slip, error) {
+	m.mu.Lock()
+	m.LoadLiveByCommitCalls = append(m.LoadLiveByCommitCalls, LoadByCommitCall{
+		Repository: repository,
+		CommitSHA:  commitSHA,
+	})
+	m.mu.Unlock()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.LoadLiveByCommitError != nil {
+		return nil, m.LoadLiveByCommitError
+	}
+
+	key := repository + ":" + commitSHA
+	correlationID, ok := m.CommitIndex[key]
+	if !ok {
+		return nil, ErrSlipNotFound
+	}
+
+	slip, ok := m.Slips[correlationID]
+	if !ok {
+		return nil, ErrSlipNotFound
+	}
+
+	// Mirror prod semantics: exclude terminal-superseded statuses.
+	if slip.Status == SlipStatusAbandoned ||
+		slip.Status == SlipStatusPromoted ||
+		slip.Status == SlipStatusCompensated {
 		return nil, ErrSlipNotFound
 	}
 
@@ -645,6 +685,7 @@ func (m *MockStore) Reset() {
 	m.CreateCalls = nil
 	m.LoadCalls = nil
 	m.LoadByCommitCalls = nil
+	m.LoadLiveByCommitCalls = nil
 	m.FindByCommitsCalls = nil
 	m.UpdateCalls = nil
 	m.UpdateStepCalls = nil

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -168,8 +168,16 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 		Warnings: make([]error, 0),
 	}
 
-	// Check for existing slip (retry detection)
-	existingSlip, err := c.store.LoadByCommit(ctx, opts.Repository, opts.CommitSHA)
+	// Check for existing slip (retry detection).
+	//
+	// Exact-SHA intent: this lookup is keyed on the precise commit SHA being pushed,
+	// not on git ancestry — we want to detect "is there an in-flight slip for THIS
+	// commit?". LoadLiveByCommit filters out superseded-terminal statuses
+	// (abandoned/promoted/compensated) at the DB layer so webhook re-deliveries
+	// after the slip was superseded don't resurrect stale rows. The IsTerminal()
+	// guard below remains because LoadLiveByCommit does NOT filter 'completed',
+	// and a completed slip must still fall through to fresh-slip creation.
+	existingSlip, err := c.store.LoadLiveByCommit(ctx, opts.Repository, opts.CommitSHA)
 	if err == nil && existingSlip != nil && !existingSlip.Status.IsTerminal() {
 		slip, err := c.handlePushRetry(ctx, existingSlip)
 		if err != nil {

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -285,6 +285,41 @@ func TestClient_CreateSlipForPush(t *testing.T) {
 		}
 	})
 
+	t.Run("retry detection uses LoadLiveByCommit not LoadByCommit", func(t *testing.T) {
+		// Guard against accidental regression of the F1 migration. CreateSlipForPush's
+		// retry-detection lookup is exact-SHA intent and must route through
+		// LoadLiveByCommit so superseded-terminal slips (abandoned/promoted/compensated)
+		// are filtered at the DB layer rather than relying solely on the post-call
+		// IsTerminal() guard. The IsTerminal() guard still catches the 'completed'
+		// case since LoadLiveByCommit does not filter completed slips.
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{})
+
+		opts := PushOptions{
+			CorrelationID: "corr-routing-check",
+			Repository:    "owner/repo",
+			Branch:        "main",
+			CommitSHA:     "routing-check-sha",
+			Components:    []ComponentDefinition{},
+		}
+
+		_, err := client.CreateSlipForPush(ctx, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(store.LoadLiveByCommitCalls) != 1 {
+			t.Errorf("expected exactly 1 LoadLiveByCommit call, got %d", len(store.LoadLiveByCommitCalls))
+		}
+		if len(store.LoadByCommitCalls) != 0 {
+			t.Errorf(
+				"expected 0 LoadByCommit calls (retry detection must use LoadLiveByCommit), got %d",
+				len(store.LoadByCommitCalls),
+			)
+		}
+	})
+
 	t.Run("validation error", func(t *testing.T) {
 		store := NewMockStore()
 		github := NewMockGitHubAPI()

--- a/slippy/resolve.go
+++ b/slippy/resolve.go
@@ -132,6 +132,16 @@ func (c *Client) ResolveSlip(ctx context.Context, opts ResolveOptions) (*Resolve
 
 		commitSHA := extractCommitFromImageTag(opts.ImageTag)
 		if commitSHA != "" {
+			// Intentionally LoadByCommit, NOT LoadLiveByCommit. The image tag encodes
+			// the exact SHA, but the *intent* here is "find the canonical slip for the
+			// image that is being deployed" — even when that slip's status has since
+			// transitioned to abandoned/promoted/compensated upstream. An image built
+			// from a slip that was later superseded (force-push, squash-merge promote,
+			// rollback) still physically exists and may still be deployed; the deploy
+			// webhook must be able to attach its state to the original build slip.
+			// Filtering terminal-superseded statuses here would drop those late-arriving
+			// deploy events on the floor. Migration to LoadLiveByCommit is NOT correct
+			// for this call site.
 			slip, err := c.store.LoadByCommit(ctx, opts.Repository, commitSHA)
 			if err == nil && slip != nil {
 				c.logger.Info(ctx, "Resolved slip via image tag", map[string]interface{}{

--- a/slippy/resolve_test.go
+++ b/slippy/resolve_test.go
@@ -251,6 +251,73 @@ func TestClient_ResolveSlip(t *testing.T) {
 	})
 }
 
+// TestResolveSlip_ImageTagFallback_ReturnsPromotedSlip asserts that the
+// image-tag fallback path in ResolveSlip (resolve.go:135) returns a slip even
+// when its status has transitioned to 'promoted'. This is the R1 contract
+// preserved by using LoadByCommit (not LoadLiveByCommit) on the fallback path:
+// late-arriving deploy events for images built from a slip that was later
+// promoted by a squash-merge upstream must still resolve to the original
+// build slip, not fail with ErrSlipNotFound.
+func TestResolveSlip_ImageTagFallback_ReturnsPromotedSlip(t *testing.T) {
+	ctx := context.Background()
+
+	store := NewMockStore()
+	github := NewMockGitHubAPI()
+	client := NewClientWithDependencies(store, github, Config{
+		AncestryDepth: 20,
+	})
+
+	// Promoted slip whose commit SHA is encoded in a downstream image tag.
+	// Use a valid 7-char lowercase hex SHA so extractCommitFromImageTag picks
+	// it up (its regex requires [a-f0-9]{7,40}).
+	promotedSlip := &Slip{
+		CorrelationID: "corr-promoted-r1",
+		Repository:    "owner/repo",
+		Branch:        "feature/x",
+		CommitSHA:     "abcdef1",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		Status:        SlipStatusPromoted,
+		Steps:         make(map[string]Step),
+	}
+	store.AddSlip(promotedSlip)
+
+	// Ancestry path must not match — force fallback to image-tag.
+	github.SetAncestry("owner", "repo", "HEAD", []string{"nomatch1", "nomatch2"})
+
+	result, err := client.ResolveSlip(ctx, ResolveOptions{
+		Repository: "owner/repo",
+		Branch:     "main",
+		Ref:        "HEAD",
+		ImageTag:   "mycarrier/svc:abcdef1-1234567890",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.Slip == nil {
+		t.Fatal("expected non-nil result and slip")
+	}
+	if result.Slip.CorrelationID != "corr-promoted-r1" {
+		t.Errorf("expected correlation_id 'corr-promoted-r1', got '%s'", result.Slip.CorrelationID)
+	}
+	if result.Slip.Status != SlipStatusPromoted {
+		t.Errorf("expected status promoted, got '%s'", result.Slip.Status)
+	}
+	if result.ResolvedBy != "image_tag" {
+		t.Errorf("expected ResolvedBy 'image_tag', got '%s'", result.ResolvedBy)
+	}
+
+	// Verify the fallback specifically used LoadByCommit (R1 contract), not
+	// LoadLiveByCommit, so that promoted slips are preserved.
+	if len(store.LoadByCommitCalls) == 0 {
+		t.Error("expected LoadByCommit to be called on image-tag fallback path")
+	}
+	if len(store.LoadLiveByCommitCalls) != 0 {
+		t.Errorf("LoadLiveByCommit must NOT be used on image-tag fallback path "+
+			"(R1 contract), got %d calls", len(store.LoadLiveByCommitCalls))
+	}
+}
+
 func TestParseRepository(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/slippy/slippytest/mock_store.go
+++ b/slippy/slippytest/mock_store.go
@@ -60,6 +60,7 @@ type MockStore struct {
 	CreateCalls           []CreateCall
 	LoadCalls             []string
 	LoadByCommitCalls     []LoadByCommitCall
+	LoadLiveByCommitCalls []LoadByCommitCall
 	FindByCommitsCalls    []FindByCommitsCall
 	FindAllByCommitsCalls []FindAllByCommitsCall
 	UpdateCalls           []UpdateCall
@@ -78,6 +79,7 @@ type MockStore struct {
 	CreateError           error
 	LoadError             error
 	LoadByCommitError     error
+	LoadLiveByCommitError error
 	FindByCommitsError    error
 	FindAllByCommitsError error
 	UpdateError           error
@@ -244,6 +246,42 @@ func (m *MockStore) LoadByCommit(ctx context.Context, repository, commitSHA stri
 
 	slip, ok := m.Slips[correlationID]
 	if !ok {
+		return nil, slippy.ErrSlipNotFound
+	}
+
+	return DeepCopySlip(slip), nil
+}
+
+// LoadLiveByCommit retrieves the most recent live slip by repository and commit SHA,
+// excluding superseded terminal statuses (abandoned, promoted, compensated).
+func (m *MockStore) LoadLiveByCommit(ctx context.Context, repository, commitSHA string) (*slippy.Slip, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.LoadLiveByCommitCalls = append(m.LoadLiveByCommitCalls, LoadByCommitCall{
+		Repository: repository,
+		CommitSHA:  commitSHA,
+	})
+
+	if m.LoadLiveByCommitError != nil {
+		return nil, m.LoadLiveByCommitError
+	}
+
+	key := repository + ":" + commitSHA
+	correlationID, ok := m.CommitIndex[key]
+	if !ok {
+		return nil, slippy.ErrSlipNotFound
+	}
+
+	slip, ok := m.Slips[correlationID]
+	if !ok {
+		return nil, slippy.ErrSlipNotFound
+	}
+
+	// Mirror prod semantics: exclude terminal-superseded statuses.
+	if slip.Status == slippy.SlipStatusAbandoned ||
+		slip.Status == slippy.SlipStatusPromoted ||
+		slip.Status == slippy.SlipStatusCompensated {
 		return nil, slippy.ErrSlipNotFound
 	}
 
@@ -612,6 +650,7 @@ func (m *MockStore) Reset() {
 	m.CreateCalls = nil
 	m.LoadCalls = nil
 	m.LoadByCommitCalls = nil
+	m.LoadLiveByCommitCalls = nil
 	m.FindByCommitsCalls = nil
 	m.FindAllByCommitsCalls = nil
 	m.UpdateCalls = nil


### PR DESCRIPTION
## Round 3 update (2026-06-12) — post-merge follow-ups applied

After Round 2 the PR was re-reviewed cross-repo and three additional polish items were applied in the same commit (amended, force-pushed). All gates re-ran cleanly (lint, unit tests, govulncheck, integration tests — the 3 pre-existing tolerated integration failures unchanged from Round 2):

- **F9 — Empty-arg defense in `LoadLiveByCommit`** — added explicit nil-check guards (`repository == ""` / `commit_sha == ""`) at the top of the function body, alongside the existing `pipelineConfig` guard. Returns a typed `fmt.Errorf` instead of generating a malformed SQL statement and tripping ClickHouse. Mirrors no existing pattern in `LoadByCommit` (left untouched — separate concern).
- **F8 — Doc clarification on `LoadLiveByCommit`** — augmented the existing doc-block with an explicit paragraph explaining why `'completed'` is intentionally NOT in the `NOT IN` list. Cites the canonical caller-side `IsTerminal()` guard pattern in `slip_writer.go:awaitExistingSlip` and `push.go:CreateSlipForPush`, and explains that filtering `completed` here would cause status-reporting callers (build dashboards, deploy webhooks) to receive false `ErrSlipNotFound` for slips that succeeded. Doc-only — the SQL `WHERE` clause is unchanged.
- **audit-F11 — Unit test for `resolve.go:135` image-tag fallback (R1 contract)** — added `TestResolveSlip_ImageTagFallback_ReturnsPromotedSlip` asserting that when the image-tag fallback path matches a `promoted` slip, `ResolveSlip` returns it (rather than dropping the late-arriving deploy event). The test also asserts that the fallback called `LoadByCommit` and did NOT call `LoadLiveByCommit`, locking in the deliberate divergence the F8 doc-block explains.
- **New beta tag** — `slippy/v1.4.0-feature-82464-add-loadlivebycommit.3`. Consumers (slippy-api PR #37) bumped accordingly.

---

## Round 2 update (2026-06-12) — pre-merge follow-ups applied

After the initial implementation, three additional issues were caught during cross-repo review and remediated in this same commit (amended, force-pushed):

- **F1 — `slippy/push.go` migrated to `LoadLiveByCommit`** — `CreateSlipForPush:171` was still calling `LoadByCommit` for the retry-detection lookup. That call is exact-SHA-by-intent (we want "is there a slip for THIS commit right now?") and was previously vulnerable to the same ancestor-resolution drift bug that motivated this PR. Migrated to `LoadLiveByCommit`. The existing `!existing.Status.IsTerminal()` guard remains because `LoadLiveByCommit` does not filter `completed` status (a completed slip must still fall through to fresh-slip creation).
- **F2 — `slippy/resolve.go:135` audit comment added** — `ResolveSlip`'s image-tag fallback intentionally keeps `LoadByCommit` (ancestry-allowed) because deploys of images built from since-superseded slips must still be attachable. Added a clear in-code comment explaining why migration is NOT correct for that call site, so a future audit doesn't churn it back-and-forth.
- **Doc-block nit** — clarified `LoadLiveByCommit`'s godoc to call out the explicit exclusion of `abandoned/promoted/compensated` (vs. just "live"), matching the SQL.

All gates re-run after amend: `make lint PKG=slippy` clean, `make test PKG=slippy` pass, integration test green.

Beta tag re-cut by CI after force-push: `slippy/v1.4.0-feature-82464-add-loadlivebycommit.1` (same name, now pointing at amended commit `13a0d7d`).

---

## Summary

Adds `LoadLiveByCommit` to the `SlipStore` interface — exact-SHA lookup that excludes `status` in `{abandoned, promoted, compensated}`. Use for in-flight dedup paths requiring "live slip for THIS exact SHA right now". Existing `LoadByCommit` kept for ancestry/image-tag/historical callers.

Fixes ADO #82464 Problem A (sibling) and unlocks the slippy-api fix for Problem B (the 129f5bc symptom).

## Why a new method, not a fix on existing `LoadByCommit`?

`store.LoadByCommit` has four callers that **require** the current "return any sign=1 row, including terminal" semantics:

- `goLibMyCarrier/slippy/resolve.go:135` — image-tag fallback; squash-merge promoted slips must remain queryable
- `pipeline-api/.../slip_client.go:118-168` — historical-by-commit endpoint
- `pushhookparser/.../rerunner.go:160-200` — reuses correlation_id of any `sign=1` row for build-version timestamp continuity
- `Slippy/.../app/app.go:406` — `slippy status --ref` CLI needs to surface abandoned/promoted to operators

Modifying `LoadByCommit` in place would break all four. The new `LoadLiveByCommit` is a sibling method for the in-flight dedup path that explicitly wants exact-SHA live-only semantics.

## What changed

- `slippy/interfaces.go` — added `LoadLiveByCommit` to `SlipStore` interface
- `slippy/clickhouse_store.go` — `*ClickHouseStore` implementation with VCMT-correct subquery (`max(version) per correlation_id` inside the (repo, sha) scope, then status filter — see below)
- `slippy/mock_store_test.go` — internal mock
- `slippy/slippytest/mock_store.go` — exported test mock
- `slippy/clickhouse_store_unit_test.go` — unit test asserting captured SQL contains the status filter and the version-collapse subquery
- `slippy/clickhouse_store_integration_test.go` — R7 integration test (`TestClickHouseStore_LoadLiveByCommit_VCMTCollapseExcludesAbandoned`) using testcontainers to verify VCMT collapse semantics
- `slippy/push.go` — **R2: migrated `CreateSlipForPush` retry detection to `LoadLiveByCommit`** (exact-SHA intent)
- `slippy/resolve.go` — **R2: added audit comment** at the deliberately-not-migrated `LoadByCommit` call site

## VCMT subtlety (caught by integration test)

`ci.routing_slips` is `SharedVersionedCollapsingMergeTree(sign, version) ORDER BY correlation_id`. Abandons write a higher-version `sign=+1` row PLUS a `sign=-1` cancel row for the prior version. Without `FINAL`, the prior-version `sign=+1 in_progress` row still satisfies a naive `WHERE sign=1 AND status NOT IN (...) ORDER BY version DESC LIMIT 1`.

The new query first picks `max(version)` per `correlation_id` within `(repo, commit)` scope, then filters by status — so an abandoned latest version excludes the entire correlation chain regardless of merge state.

## Dependency chain — read before merging

This PR is **part 1 of 2**:

1. **THIS PR** — `MyCarrier-DevOps/goLibMyCarrier#<this PR>` — add `LoadLiveByCommit` to goLibMyCarrier/slippy
2. **slippy-api consumer PR** — `MyCarrier-DevOps/slippy-api#37` — bumps go.mod to the new goLibMyCarrier tag, adds `LoadByCommitExact` adapter, migrates `slip_writer.go:349 awaitExistingSlip` (the actual fix for the 129f5bc symptom)

**Merge order:**
1. Merge THIS PR
2. CI/release pipeline cuts a new `goLibMyCarrier/slippy` tag (`v1.4.0` or next)
3. In the slippy-api PR, bump `go.mod` to the new tag
4. Re-run slippy-api gates → merge

Do NOT merge slippy-api before this PR's tag ships, or its build will break.

## Test plan
- [x] `make lint PKG=slippy` — 0 issues
- [x] `make test PKG=slippy` — slippy 83.9% / slippytest 73.9% coverage; new tests pass; existing `LoadByCommit` tests unaffected
- [x] `make check-sec PKG=slippy` — 0 vulnerabilities
- [x] `go test -tags=integration -run 'LoadLiveByCommit' ./...` — testcontainer ClickHouse run, passes in ~8s
- [x] Existing `var _ SlipStore = (*ClickHouseStore)(nil)` compile-time assertion satisfied + `*MockStore` (internal) + `*MockStore` (slippytest) updated
- [x] **R2:** push.go retry-detection migration + resolve.go audit comment — gates re-run, clean

## Risk

- **Behavior of `LoadByCommit` unchanged** — verified by existing test suite continuing to pass
- **Interface widening** — three implementers updated in this PR (production + 2 mocks); any external consumer that implements `SlipStore` will need to add the method (none known)
- **VCMT collapse semantics** — verified empirically via the R7 integration test
- **R2 push.go migration** — narrow behavioral change for retry detection: now correctly ignores abandoned/promoted/compensated rather than letting them mask as in-flight; the terminal-status guard already exists as defense-in-depth

## ADO
Related-ADO: 82464

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

