### PR TITLE
feat(slippy): enhance slip handling for failed existing slips to supersede and create fresh slips

### DIFF
--- a/slippy/push.go
+++ b/slippy/push.go
@@ -142,13 +142,17 @@ type CreateSlipResult struct {
 // finds any existing slips for ancestor commits, and ensures they are
 // in a terminal state (abandoning non-terminal slips that are being superseded).
 //
-// Retry vs new-slip behavior for the same commit SHA:
-//   - If an existing slip is found and is non-terminal (in_progress, failed, etc.),
-//     it is retried via handlePushRetry (same correlation ID is reused).
-//   - If an existing slip is found and is terminal (abandoned, promoted, compensated,
-//     completed), it is treated as stale and a fresh slip is created with the new
-//     correlation ID from opts. This prevents resurrecting superseded slips on
-//     webhook re-delivery or bot-commit races.
+// Retry vs supersede vs new-slip behavior for the same commit SHA:
+//   - Existing slip is non-terminal AND in_progress/pending/compensating: retried via
+//     handlePushRetry (same correlation ID is reused) — the pipeline is still in flight,
+//     so re-dispatching would double-run work.
+//   - Existing slip is failed: the stuck slip is abandoned and a fresh slip is created
+//     with the new correlation ID from opts. A failed slip never advances without a step
+//     re-run, so a new push for the same commit (retrigger-ci replay, or webhook
+//     re-delivery of a failed run) is treated as a deliberate request to run CI again.
+//   - Existing slip is terminal (abandoned, promoted, compensated, completed): treated as
+//     stale and a fresh slip is created with the new correlation ID from opts. This
+//     prevents resurrecting superseded slips on webhook re-delivery or bot-commit races.
 //
 // The returned CreateSlipResult contains both the slip and any non-fatal errors
 // that occurred during processing (e.g., ancestry resolution failures).
@@ -168,7 +172,7 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 		Warnings: make([]error, 0),
 	}
 
-	// Check for existing slip (retry detection).
+	// Check for existing slip (retry detection / same-commit supersede decision).
 	//
 	// Exact-SHA intent: this lookup is keyed on the precise commit SHA being pushed,
 	// not on git ancestry — we want to detect "is there an in-flight slip for THIS
@@ -179,13 +183,50 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 	// and a completed slip must still fall through to fresh-slip creation.
 	existingSlip, err := c.store.LoadLiveByCommit(ctx, opts.Repository, opts.CommitSHA)
 	if err == nil && existingSlip != nil && !existingSlip.Status.IsTerminal() {
-		slip, err := c.handlePushRetry(ctx, existingSlip)
-		if err != nil {
-			return nil, err
+		// A live (non-terminal) slip already exists for this EXACT commit. What we do
+		// next depends on whether the prior pipeline can still make progress on its own:
+		//
+		//   - in_progress / pending / compensating: the prior pipeline is actively
+		//     running (or a concurrent create just won the repo:sha race). Reuse the
+		//     existing slip and reset push_parsed via handlePushRetry — re-dispatching
+		//     builds here would double-run work that is already in flight. The caller
+		//     (slippy-api → pushhookparser) detects that the returned correlation_id
+		//     differs from the one it sent and suppresses duplicate side-effects.
+		//
+		//   - failed: the prior pipeline is stuck. A failed slip never advances on its
+		//     own — it only recovers when its failed STEPS are re-run, which a fresh
+		//     push event does not do. So a new push for the same commit (a retrigger-ci
+		//     replay, or a webhook re-delivery of a failed run) is a deliberate request
+		//     to run CI again. Abandon the failed slip and fall through to fresh-slip
+		//     creation with the caller's correlation_id, so the caller sees a NEW slip
+		//     (not a dedup) and re-dispatches builds + unit tests. This is the
+		//     same-commit case of the "next push supersedes the old slip, creates a new
+		//     one" model (STATE_MACHINE_V3.md §"Pipeline termination without completing").
+		if existingSlip.Status != SlipStatusFailed {
+			slip, retryErr := c.handlePushRetry(ctx, existingSlip)
+			if retryErr != nil {
+				return nil, retryErr
+			}
+			result.Slip = slip
+			result.AncestryResolved = len(slip.Ancestry) > 0
+			return result, nil
 		}
-		result.Slip = slip
-		result.AncestryResolved = len(slip.Ancestry) > 0
-		return result, nil
+
+		c.logger.Info(ctx, "Superseding failed slip for same commit (retrigger / re-run)", map[string]interface{}{
+			"superseded_id":     existingSlip.CorrelationID,
+			"superseded_commit": shortSHA(existingSlip.CommitSHA),
+			"superseded_status": string(existingSlip.Status),
+			"superseding_id":    opts.CorrelationID,
+		})
+		if abandonErr := c.AbandonSlip(ctx, existingSlip.CorrelationID, opts.CorrelationID); abandonErr != nil {
+			// Non-fatal: record as a warning and still create the fresh slip. A
+			// lingering non-terminal failed row is shadowed by the newer slip
+			// (LoadLiveByCommit orders by version DESC), and blocking fresh-slip
+			// creation here would re-introduce the "retrigger never builds" bug.
+			result.Warnings = append(result.Warnings,
+				fmt.Errorf("failed to abandon superseded failed slip %s: %w", existingSlip.CorrelationID, abandonErr))
+		}
+		// fall through to fresh-slip creation with opts.CorrelationID
 	}
 
 	// Resolve ancestry chain and abandon superseded slips

--- a/slippy/push.go
+++ b/slippy/push.go
@@ -183,15 +183,9 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 	// and a completed slip must still fall through to fresh-slip creation.
 	existingSlip, err := c.store.LoadLiveByCommit(ctx, opts.Repository, opts.CommitSHA)
 	if err == nil && existingSlip != nil && !existingSlip.Status.IsTerminal() {
-		// A live (non-terminal) slip already exists for this EXACT commit. What we do
-		// next depends on whether the prior pipeline can still make progress on its own:
-		//
-		//   - in_progress / pending / compensating: the prior pipeline is actively
-		//     running (or a concurrent create just won the repo:sha race). Reuse the
-		//     existing slip and reset push_parsed via handlePushRetry — re-dispatching
-		//     builds here would double-run work that is already in flight. The caller
-		//     (slippy-api → pushhookparser) detects that the returned correlation_id
-		//     differs from the one it sent and suppresses duplicate side-effects.
+		// A live (non-terminal) slip already exists for this EXACT commit (existingSlip.Status
+		// is a SlipStatus, not a step status). What we do next depends on whether the prior
+		// pipeline can still make progress on its own:
 		//
 		//   - failed: the prior pipeline is stuck. A failed slip never advances on its
 		//     own — it only recovers when its failed STEPS are re-run, which a fresh
@@ -202,6 +196,15 @@ func (c *Client) CreateSlipForPush(ctx context.Context, opts PushOptions) (*Crea
 		//     (not a dedup) and re-dispatches builds + unit tests. This is the
 		//     same-commit case of the "next push supersedes the old slip, creates a new
 		//     one" model (STATE_MACHINE_V3.md §"Pipeline termination without completing").
+		//
+		//   - any OTHER non-terminal slip status — in_progress in practice (the enum also
+		//     defines pending/compensating, which this pipeline does not use; see
+		//     STATE_MACHINE_V3.md): the prior pipeline is still in flight, or a concurrent
+		//     create just won the repo:sha race. Reuse the existing slip and reset
+		//     push_parsed via handlePushRetry — re-dispatching builds here would double-run
+		//     work that is already running. The caller (slippy-api → pushhookparser) detects
+		//     that the returned correlation_id differs from the one it sent and suppresses
+		//     duplicate side-effects.
 		if existingSlip.Status != SlipStatusFailed {
 			slip, retryErr := c.handlePushRetry(ctx, existingSlip)
 			if retryErr != nil {

--- a/slippy/push_test.go
+++ b/slippy/push_test.go
@@ -226,6 +226,110 @@ func TestClient_CreateSlipForPush(t *testing.T) {
 		}
 	})
 
+	t.Run("failed existing slip - supersedes and creates fresh", func(t *testing.T) {
+		// A prior pipeline for this EXACT commit ran and FAILED (non-terminal, stuck).
+		// A new push for the same commit (retrigger-ci replay, or webhook re-delivery of
+		// a failed run) must abandon the failed slip and create a FRESH slip with the
+		// caller's correlation ID — NOT reuse it via handlePushRetry. Reusing it returns
+		// a different correlation ID to the caller (slippy-api → pushhookparser), which
+		// reads that as a dedup and suppresses builds + unit tests (the retrigger bug).
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		config := testPipelineConfig()
+		client := NewClientWithDependencies(store, github, Config{PipelineConfig: config})
+
+		store.AddSlip(&Slip{
+			CorrelationID: "corr-old-failed",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "failed-commit-xyz",
+			Status:        SlipStatusFailed,
+			Steps: map[string]Step{
+				"builds": {Status: StepStatusFailed},
+			},
+			StateHistory: []StateHistoryEntry{},
+		})
+
+		opts := PushOptions{
+			CorrelationID: "corr-retrigger-new",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "failed-commit-xyz", // same commit — a retrigger replay
+			Components:    []ComponentDefinition{{Name: "api", DockerfilePath: "src/MC.Api"}},
+		}
+
+		result, err := client.CreateSlipForPush(ctx, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Must return the NEW slip so the caller does not see a dedup.
+		if result.Slip.CorrelationID != "corr-retrigger-new" {
+			t.Errorf("expected new slip ID 'corr-retrigger-new', got '%s'", result.Slip.CorrelationID)
+		}
+		// Exactly one Create call for the fresh slip.
+		if len(store.CreateCalls) != 1 {
+			t.Errorf("expected 1 Create call for fresh slip, got %d", len(store.CreateCalls))
+		}
+		// The old failed slip must be abandoned (terminal, excluded from future live lookups).
+		old, ok := store.Slips["corr-old-failed"]
+		if !ok {
+			t.Fatal("old slip missing from store")
+		}
+		if old.Status != SlipStatusAbandoned {
+			t.Errorf("expected old failed slip to be abandoned, got %q", old.Status)
+		}
+		// handlePushRetry (reset push_parsed -> running) must NOT run for a failed slip.
+		for _, call := range store.UpdateStepCalls {
+			if call.StepName == "push_parsed" && call.Status == StepStatusRunning {
+				t.Error("handlePushRetry must not run for a failed existing slip (should supersede)")
+			}
+		}
+	})
+
+	t.Run("failed existing slip - abandon error is non-fatal, still creates fresh", func(t *testing.T) {
+		// If abandoning the failed slip fails, slip creation must still proceed (with a
+		// recorded warning). Blocking here would re-introduce the "retrigger never builds"
+		// bug; a lingering failed row is shadowed by the newer slip (version DESC).
+		store := NewMockStore()
+		github := NewMockGitHubAPI()
+		client := NewClientWithDependencies(store, github, Config{})
+
+		store.AddSlip(&Slip{
+			CorrelationID: "corr-old-failed-2",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "failed-commit-abc",
+			Status:        SlipStatusFailed,
+			Steps:         map[string]Step{"builds": {Status: StepStatusFailed}},
+			StateHistory:  []StateHistoryEntry{},
+		})
+		// AbandonSlip internally does Load + Update; fail the Update so abandon errors.
+		// (Create is unaffected by UpdateError, so fresh-slip creation still succeeds.)
+		store.UpdateError = errors.New("clickhouse unavailable")
+
+		opts := PushOptions{
+			CorrelationID: "corr-retrigger-2",
+			Repository:    "owner/repo",
+			Branch:        "integration",
+			CommitSHA:     "failed-commit-abc",
+		}
+
+		result, err := client.CreateSlipForPush(ctx, opts)
+		if err != nil {
+			t.Fatalf("unexpected error (abandon failure must be non-fatal): %v", err)
+		}
+		if result.Slip.CorrelationID != "corr-retrigger-2" {
+			t.Errorf("expected fresh slip 'corr-retrigger-2', got '%s'", result.Slip.CorrelationID)
+		}
+		if len(store.CreateCalls) != 1 {
+			t.Errorf("expected 1 Create call, got %d", len(store.CreateCalls))
+		}
+		if len(result.Warnings) == 0 {
+			t.Error("expected a warning recorded for the failed abandon")
+		}
+	})
+
 	t.Run("new slip for terminal existing slip", func(t *testing.T) {
 		// When a terminal slip (abandoned, promoted, compensated, completed) already
 		// exists for the commit SHA, CreateSlipForPush must NOT call handlePushRetry.


### PR DESCRIPTION
# fix(slippy): supersede a failed same-commit slip on push instead of dedup-suppressing it

## Summary

`CreateSlipForPush` now **abandons a `failed` same-commit slip and creates a fresh one**
(with the caller's correlation_id) when a new push arrives for that exact commit. Previously
it reused the failed slip via `handlePushRetry`, which returned the slip's *original*
correlation_id — read downstream as a dedup, suppressing builds and unit tests.

This fixes **"Retrigger CI does not kick off builds/unit-tests"** for the most common case:
retriggering a commit whose previous pipeline failed.

## Background / why

admin's "Retrigger Builds and Unit Tests" workflow was rewritten (admin #73) to send a
synthetic **push** (rather than the old `action:"rerun"`) that flows through
pushhookparser → slippy-api → `CreateSlipForPush`. A retrigger replays an *existing* commit,
so it collides with that commit's existing routing slip.

`LoadLiveByCommit` excludes only `abandoned/promoted/compensated` (`query_builder.go:127`).
**`failed` is non-terminal** (`status.go:46-55`), so it was returned and handled by
`handlePushRetry`, which reuses the existing slip and returns its original correlation_id.
Downstream (slippy-api returns `result.Slip` verbatim → pushhookparser computes
`Deduplicated = returnedID != sentID`) this looks identical to a concurrent-create dedup, so
pushhookparser short-circuits before emitting any `git.push`/`unit.tester` events.

Observed in production (`pushhookparser.log`), even with builds force-enabled:

```
slip deduplicated: local=c146dc61… authoritative=8cba1e73… repo=…/MC.MyCarrier.Frontend sha=0d559d9e…
Duplicate push suppressed: slip already exists (…); short-circuiting check-runs, build dispatch, and auto-deploy
```

## What changed

`slippy/push.go` — `CreateSlipForPush`, the existing-slip branch is now aware of the
existing slip's **slip status** (`SlipStatus` of `existingSlip`, not a step status):

| Existing same-commit slip status | Before | After |
|---|---|---|
| none | create fresh | create fresh (unchanged) |
| any non-terminal except `failed` (`in_progress` in practice) | reuse via `handlePushRetry` | reuse via `handlePushRetry` (**unchanged** — pipeline is in flight; don't double-dispatch) |
| **`failed`** | reuse via `handlePushRetry` → dedup-suppressed downstream ❌ | **abandon + create fresh with caller's correlation_id** → downstream re-dispatches builds/tests ✅ |
| terminal (`completed`/`abandoned`/`promoted`/`compensated`) | create fresh | create fresh (unchanged) |

> Note: the branch special-cases `failed` only (`!= SlipStatusFailed`); every other
> non-terminal status falls to `handlePushRetry`. Per `STATE_MACHINE_V3.md` production slips
> only use `in_progress / failed / completed / abandoned / promoted`, so `in_progress` is the
> only "other non-terminal" status that occurs here in practice (`pending`/`compensating`
> are defined enum values this pipeline does not enter).

A failed slip never advances on its own (it recovers only when its failed *steps* are
re-run, which a fresh push event does not do), so a new push for the same commit is a
deliberate "run CI again" request. This is the same-commit case of the existing supersede
model in `STATE_MACHINE_V3.md` (§"Pipeline termination without completing": *next push
abandons the old slip, creates a new one*).

Abandon failure is **non-fatal**: a warning is recorded and fresh-slip creation still
proceeds. A lingering failed row is shadowed by the newer slip (`version DESC`); blocking
here would re-introduce the bug.

## Invariant / state-machine safety

- Touches neither `checkPipelineCompletion` nor any step transition — invariants **I1–I5 are
  unaffected**. `TestStateMachine_*` remains green.
- No change to exported signatures (`CreateSlipForPush`, `PushOptions`, `CreateSlipResult`,
  `AbandonSlip`) — consumers (slippy-api) compile and behave identically aside from the
  intended push-path change.

## Tests

`slippy/push_test.go`:
- `failed existing slip - supersedes and creates fresh` — asserts the new slip's
  correlation_id is returned, exactly one `Create`, and the old failed slip is abandoned;
  `handlePushRetry` does **not** run.
- `failed existing slip - abandon error is non-fatal, still creates fresh` — injects an
  abandon (Update) error and asserts a fresh slip is still created with a recorded warning.
- Existing `retry - existing slip` (uses `in_progress`) is unchanged and still passes —
  guards that genuinely in-flight slips are never superseded.

## Validation

```
make lint PKG=slippy     # 0 issues
make test PKG=slippy      # pass (race + coverage 82.8%)
go test -run TestStateMachine ./slippy/...   # I1–I5 green
```

Compatibility: built `slippy-api` against this branch via a local `replace` →
`go build ./...` OK (no signature/behavior changes required in slippy-api).

## Rollout

This is the shared library; runtime behavior changes only once **slippy-api** picks it up:

1. Merge + tag a new `goLibMyCarrier/slippy` release.
2. `slippy-api`: `go get …/goLibMyCarrier/slippy@vX.Y.Z` → `go mod tidy` →
   `make lint && make test` (per slippy-api "Slippy Bump Checklist") → release → deploy.
3. No change needed in pushhookparser or admin.
4. Verify: retrigger a known-failed commit → confirm a NEW correlation_id with
   `git.push` + `unit.tester` events and no "Duplicate push suppressed".

## Risk / edge cases

- **Webhook re-delivery of a failed run** now re-runs CI (abandon + fresh) rather than
  no-op. Benign (re-running a failed pipeline is desirable) and rare.
- **Narrow race**: a brand-new push that fails within the slippy-api repo:sha lock TTL while
  a duplicate delivery retries could abandon+recreate. Bounded by that lock; worst case is
  one duplicate build of a just-failed commit.
- **Only `failed` is superseded.** Any other non-terminal slip status reuses the existing
  slip (`handlePushRetry`), so genuinely in-flight pipelines are never double-dispatched.
