### PR TITLE
feat(clickhouse): add connection pool settings and update error handling for context cancellations

### DIFF
--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -37,6 +38,38 @@ func Named(name string, value interface{}) driver.NamedValue {
 // This can be overridden in tests for faster execution.
 var DefaultRetryIntervals = []time.Duration{2 * time.Second, 3 * time.Second, 5 * time.Second}
 
+// Connection pool defaults. Applied when ClickhouseConfig leaves the field
+// zero-valued. ConnMaxLifetime is kept short so that stale connections behind
+// LBs/firewalls (which may silently half-close idle peers) are reaped quickly
+// rather than blocking the next request until TCP retransmission timeout.
+const (
+	DefaultMaxOpenConns    = 50
+	DefaultMaxIdleConns    = 10
+	DefaultConnMaxLifetime = 60 * time.Second
+)
+
+// ResolvePoolSettings returns the connection-pool values to use, substituting
+// the package defaults for any zero-valued field in cfg. Exported so callers
+// (and tests) can introspect what will actually be applied to the driver.
+func ResolvePoolSettings(cfg *ClickhouseConfig) (maxOpen, maxIdle int, lifetime time.Duration) {
+	maxOpen = DefaultMaxOpenConns
+	maxIdle = DefaultMaxIdleConns
+	lifetime = DefaultConnMaxLifetime
+	if cfg == nil {
+		return maxOpen, maxIdle, lifetime
+	}
+	if cfg.MaxOpenConns > 0 {
+		maxOpen = cfg.MaxOpenConns
+	}
+	if cfg.MaxIdleConns > 0 {
+		maxIdle = cfg.MaxIdleConns
+	}
+	if cfg.ConnMaxLifetime > 0 {
+		lifetime = cfg.ConnMaxLifetime
+	}
+	return maxOpen, maxIdle, lifetime
+}
+
 // ErrNilViper is returned by ClickhouseLoadConfigFromViper when the caller
 // passes a nil *viper.Viper. Exported as a sentinel so callers can match it
 // with errors.Is rather than string comparison.
@@ -46,8 +79,17 @@ var ErrNilViper = errors.New("viper instance cannot be nil")
 // worth retrying) or permanent (e.g. syntax error, authentication failure).
 // Server-side exceptions (clickhouse.Exception) are treated as non-transient
 // since they indicate query or configuration problems that won't resolve on retry.
+//
+// Context cancellation errors (context.Canceled, context.DeadlineExceeded) are
+// also treated as non-transient: the caller has explicitly given up, so retrying
+// is wrong. Treating them as transient sends the wrapper into a retry loop whose
+// first select{} immediately fires ctx.Done(), producing the misleading
+// "operation cancelled after 0 retries" wrap that hides the actual cancellation.
 func isTransientError(err error) bool {
 	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	var exception *clickhouse.Exception
@@ -140,6 +182,12 @@ type ClickhouseConfig struct {
 	ChDatabase   string `mapstructure:"chdatabase"`
 	ChSkipVerify string `mapstructure:"chskipverify"`
 	ChPort       string `mapstructure:"chport"`
+
+	// Connection-pool tunables. Leave zero to inherit the package defaults
+	// (see DefaultMaxOpenConns, DefaultMaxIdleConns, DefaultConnMaxLifetime).
+	MaxOpenConns    int           `mapstructure:"maxopenconns"`
+	MaxIdleConns    int           `mapstructure:"maxidleconns"`
+	ConnMaxLifetime time.Duration `mapstructure:"connmaxlifetime"`
 }
 
 // LoadConfig loads the configuration from environment variables using Viper.
@@ -167,6 +215,15 @@ func ClickhouseLoadConfig() (*ClickhouseConfig, error) {
 	}
 	if err := v.BindEnv("chport", "CLICKHOUSE_PORT"); err != nil {
 		return nil, fmt.Errorf("failed to bind environment variable for chport: %w", err)
+	}
+	if err := v.BindEnv("maxopenconns", "CLICKHOUSE_MAX_OPEN_CONNS"); err != nil {
+		return nil, fmt.Errorf("failed to bind environment variable for maxopenconns: %w", err)
+	}
+	if err := v.BindEnv("maxidleconns", "CLICKHOUSE_MAX_IDLE_CONNS"); err != nil {
+		return nil, fmt.Errorf("failed to bind environment variable for maxidleconns: %w", err)
+	}
+	if err := v.BindEnv("connmaxlifetime", "CLICKHOUSE_CONN_MAX_LIFETIME"); err != nil {
+		return nil, fmt.Errorf("failed to bind environment variable for connmaxlifetime: %w", err)
 	}
 
 	// Read environment variables
@@ -201,8 +258,12 @@ func ClickhouseLoadConfigFromViper(v *viper.Viper) (*ClickhouseConfig, error) {
 
 	var ClickhouseConfig ClickhouseConfig
 
-	// Unmarshal viper values into the Config struct
-	if err := v.Unmarshal(&ClickhouseConfig); err != nil {
+	// Unmarshal viper values into the Config struct. The duration decode hook
+	// lets ConnMaxLifetime be set via env (e.g. CLICKHOUSE_CONN_MAX_LIFETIME=60s)
+	// since AutomaticEnv only produces strings.
+	if err := v.Unmarshal(&ClickhouseConfig, viper.DecodeHook(
+		mapstructure.StringToTimeDurationHookFunc(),
+	)); err != nil {
 		return nil, fmt.Errorf("unable to decode into struct, %w", err)
 	}
 
@@ -303,6 +364,7 @@ func (chsession *ClickhouseSession) Connect(ch *ClickhouseConfig, ctx context.Co
 	// Capture skipVerify by value so the DialContext closure does not retain
 	// a reference to the entire ClickhouseSession for the pool's lifetime.
 	skipVerify := chsession.skipVerify
+	maxOpen, maxIdle, lifetime := ResolvePoolSettings(ch)
 
 	return retryOperation(ctx, func() error {
 		conn, err := clickhouse.Open(&clickhouse.Options{
@@ -335,9 +397,9 @@ func (chsession *ClickhouseSession) Connect(ch *ClickhouseConfig, ctx context.Co
 					&tls.Config{InsecureSkipVerify: skipVerify},
 				)
 			},
-			ConnMaxLifetime: 5 * time.Minute,
-			MaxOpenConns:    10,
-			MaxIdleConns:    5,
+			ConnMaxLifetime: lifetime,
+			MaxOpenConns:    maxOpen,
+			MaxIdleConns:    maxIdle,
 		})
 		if err != nil {
 			return fmt.Errorf("error connecting to ClickHouse: %w", err)

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -2037,6 +2037,26 @@ func TestIsTransientError(t *testing.T) {
 			}),
 			expected: false,
 		},
+		{
+			name:     "context.Canceled is NOT transient",
+			err:      context.Canceled,
+			expected: false,
+		},
+		{
+			name:     "context.DeadlineExceeded is NOT transient",
+			err:      context.DeadlineExceeded,
+			expected: false,
+		},
+		{
+			name:     "wrapped context.Canceled is NOT transient",
+			err:      fmt.Errorf("query: %w", context.Canceled),
+			expected: false,
+		},
+		{
+			name:     "wrapped context.DeadlineExceeded is NOT transient",
+			err:      fmt.Errorf("query: %w", context.DeadlineExceeded),
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2045,6 +2065,116 @@ func TestIsTransientError(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// Test that retryOperation returns context errors immediately without entering
+// the retry loop. Previously, ctx.Canceled was classified as transient, sending
+// retryOperation into a loop whose first select{} fired ctx.Done() and produced
+// the misleading "operation cancelled after 0 retries: context canceled" wrap.
+func TestRetryOperation_FirstAttemptCanceled_ReturnsCanceled(t *testing.T) {
+	defer setTestRetryIntervals()()
+
+	ctx := context.Background()
+	callCount := 0
+
+	err := retryOperation(ctx, func() error {
+		callCount++
+		return context.Canceled
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, callCount, "context.Canceled must not be retried")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), "operation cancelled after",
+		"context errors must surface directly, not wrapped in misleading retry message")
+}
+
+func TestRetryOperation_FirstAttemptDeadlineExceeded_ReturnsDeadlineExceeded(t *testing.T) {
+	defer setTestRetryIntervals()()
+
+	ctx := context.Background()
+	callCount := 0
+
+	err := retryOperation(ctx, func() error {
+		callCount++
+		return context.DeadlineExceeded
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, callCount, "context.DeadlineExceeded must not be retried")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotContains(t, err.Error(), "operation cancelled after")
+}
+
+func TestRetryOperation_WrappedContextCanceled_ReturnsImmediately(t *testing.T) {
+	defer setTestRetryIntervals()()
+
+	ctx := context.Background()
+	callCount := 0
+	wrapped := fmt.Errorf("clickhouse exec: %w", context.Canceled)
+
+	err := retryOperation(ctx, func() error {
+		callCount++
+		return wrapped
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, callCount, "wrapped context.Canceled must not be retried")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResolvePoolSettings_Defaults(t *testing.T) {
+	maxOpen, maxIdle, lifetime := ResolvePoolSettings(&ClickhouseConfig{})
+	assert.Equal(t, DefaultMaxOpenConns, maxOpen)
+	assert.Equal(t, DefaultMaxIdleConns, maxIdle)
+	assert.Equal(t, DefaultConnMaxLifetime, lifetime)
+}
+
+func TestResolvePoolSettings_NilConfig(t *testing.T) {
+	maxOpen, maxIdle, lifetime := ResolvePoolSettings(nil)
+	assert.Equal(t, DefaultMaxOpenConns, maxOpen)
+	assert.Equal(t, DefaultMaxIdleConns, maxIdle)
+	assert.Equal(t, DefaultConnMaxLifetime, lifetime)
+}
+
+func TestResolvePoolSettings_Overrides(t *testing.T) {
+	maxOpen, maxIdle, lifetime := ResolvePoolSettings(&ClickhouseConfig{
+		MaxOpenConns:    25,
+		MaxIdleConns:    7,
+		ConnMaxLifetime: 2 * time.Minute,
+	})
+	assert.Equal(t, 25, maxOpen)
+	assert.Equal(t, 7, maxIdle)
+	assert.Equal(t, 2*time.Minute, lifetime)
+}
+
+func TestResolvePoolSettings_NegativeFallsBackToDefaults(t *testing.T) {
+	maxOpen, maxIdle, lifetime := ResolvePoolSettings(&ClickhouseConfig{
+		MaxOpenConns:    -1,
+		MaxIdleConns:    -1,
+		ConnMaxLifetime: -1 * time.Second,
+	})
+	assert.Equal(t, DefaultMaxOpenConns, maxOpen)
+	assert.Equal(t, DefaultMaxIdleConns, maxIdle)
+	assert.Equal(t, DefaultConnMaxLifetime, lifetime)
+}
+
+func TestClickhouseLoadConfig_PoolEnvOverrides(t *testing.T) {
+	t.Setenv("CLICKHOUSE_HOSTNAME", "host")
+	t.Setenv("CLICKHOUSE_USERNAME", "user")
+	t.Setenv("CLICKHOUSE_PASSWORD", "pass")
+	t.Setenv("CLICKHOUSE_DATABASE", "db")
+	t.Setenv("CLICKHOUSE_PORT", "9440")
+	t.Setenv("CLICKHOUSE_SKIP_VERIFY", "false")
+	t.Setenv("CLICKHOUSE_MAX_OPEN_CONNS", "33")
+	t.Setenv("CLICKHOUSE_MAX_IDLE_CONNS", "11")
+	t.Setenv("CLICKHOUSE_CONN_MAX_LIFETIME", "90s")
+
+	cfg, err := ClickhouseLoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 33, cfg.MaxOpenConns)
+	assert.Equal(t, 11, cfg.MaxIdleConns)
+	assert.Equal(t, 90*time.Second, cfg.ConnMaxLifetime)
 }
 
 func TestClickhouseSession_Ping_NilConnection(t *testing.T) {

--- a/clickhouse/go.mod
+++ b/clickhouse/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.45.0
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -16,7 +17,6 @@ require (
 	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect


### PR DESCRIPTION
# fix(clickhouse): context errors are non-transient; tunable connection pool

## Summary

Two related fixes in the `clickhouse` module to make slippy-api's `POST /v1/slips/{id}/steps/{name}/{action}` endpoints survive transient ClickHouse hiccups instead of intermittently returning a misleading `HTTP 422 — "operation cancelled after 0 retries: context canceled"`.

- **Fix 1 — `isTransientError` no longer treats context cancellation as transient.** Previously, any error that wasn't a `*clickhouse.Exception` was retried. `context.Canceled` / `context.DeadlineExceeded` fell into that bucket: `retryOperation` would enter the retry loop, the very first `select{}` would immediately fire `ctx.Done()`, and the call would return the misleading `"operation cancelled after 0 retries: context canceled"` wrap that hid the real cause. With this fix, those errors return immediately as themselves.
- **Fix 2 — `ClickhouseConfig` gains optional pool tunables.** New fields `MaxOpenConns`, `MaxIdleConns`, `ConnMaxLifetime` (with package defaults of `50 / 10 / 60s`, raised from the previous hardcoded `10 / 5 / 5m`). Zero-valued fields fall back to the new defaults, so existing callers automatically get the improved settings on a version bump. Shorter `ConnMaxLifetime` reaps connections faster after LB/firewall idle drops, reducing the window where a poisoned pool requires a pod restart to clear.

## Why now

Production was seeing intermittent `422`s on `/start`, `/complete`, `/fail`. The error string traced back to `retryOperation` at `clickhouse.go:78` — the wrapper was treating cancellation as a network failure and re-arming a retry that ctx.Done would immediately cancel. Combined with a tiny `MaxIdleConns=5` pool and a 5-minute `ConnMaxLifetime`, a single bad upstream rotation could poison the pool long enough to require a pod restart. Both behaviors are surgical fixes; no API breakage.

## Key technical decisions

- **Surgical scope on `isTransientError`.** The only behavior change is "context errors are now non-transient." Server exceptions remain non-transient; network/EOF/timeout-shaped errors remain transient. Callers that previously over-retried on cancellation now fail fast with the original error, which is the correct semantic.
- **Defaults applied via `ResolvePoolSettings`, not in `Connect`.** A standalone helper means the resolution rule (zero → default) is unit-testable and inspectable by callers who want to log what's actually in effect. `Connect` calls it once at session creation.
- **Defaults raised, not removed.** The previous values were defensive but too conservative. `50 / 10 / 60s` matches the pattern most ClickHouse-backed services run in. Callers who care can still override via config or env.
- **Env binding uses a duration decode hook.** `CLICKHOUSE_CONN_MAX_LIFETIME=90s` parses cleanly into `time.Duration` thanks to `mapstructure.StringToTimeDurationHookFunc()`. No string-and-manual-parse hack.
- **Backward compatibility.** Pure additions to `ClickhouseConfig`; no existing call site needs to change. `mapstructure/v2` was already an indirect dep of viper — promoted to direct so the decode hook can be imported.

## Files changed

| Area | Files |
|---|---|
| Library | `clickhouse/clickhouse.go` |
| Tests | `clickhouse/clickhouse_test.go` |
| Module | `clickhouse/go.mod` (mapstructure/v2 indirect → direct) |

## New config surface

| Field | Env var | Default | Notes |
|---|---|---|---|
| `MaxOpenConns` | `CLICKHOUSE_MAX_OPEN_CONNS` | `50` | was hardcoded `10` |
| `MaxIdleConns` | `CLICKHOUSE_MAX_IDLE_CONNS` | `10` | was hardcoded `5` |
| `ConnMaxLifetime` | `CLICKHOUSE_CONN_MAX_LIFETIME` | `60s` | was hardcoded `5m` |

Set the field (or env var) explicitly to override. Leave it zero to inherit the package default — that's the path every existing caller will follow until they opt in.

## Test plan

- [x] `make test PKG=clickhouse` — all pass, 89.9% coverage
- [x] `make lint PKG=clickhouse` — 0 issues
- [x] Dependent modules build cleanly: `slippy`, `clickhousemigrator`
- [x] New unit tests:
  - `TestIsTransientError` — extended with `context.Canceled` / `context.DeadlineExceeded` (naked + wrapped) cases
  - `TestRetryOperation_FirstAttemptCanceled_ReturnsCanceled` — asserts `1` call, error is `context.Canceled`, message does NOT contain `"operation cancelled after"`
  - `TestRetryOperation_FirstAttemptDeadlineExceeded_ReturnsDeadlineExceeded` — same for deadline
  - `TestRetryOperation_WrappedContextCanceled_ReturnsImmediately` — confirms `errors.Is` unwrap path
  - `TestResolvePoolSettings_Defaults` / `_NilConfig` / `_Overrides` / `_NegativeFallsBackToDefaults`
  - `TestClickhouseLoadConfig_PoolEnvOverrides` — confirms env binding + duration parse

## Follow-ups (separate PR — slippy-api)

After this lands and gets tagged:

1. Bump `goLibMyCarrier/clickhouse` and `goLibMyCarrier/slippy` in slippy-api.
2. Map `context.Canceled` / `context.DeadlineExceeded` to `504` in `mapWriteError` (today they fall through to `422` via `*StepError`).
3. Decouple the ClickHouse write path in `slip_writer.go` from the HTTP request context using `context.WithoutCancel + 15s timeout` (mirroring the existing dedup-lock-release pattern at `slip_writer.go:113`).

## Risk

- **Low.** Retry behavior change is strictly more correct — over-retrying on cancellation was always wrong. Pool defaults are higher than before; if ClickHouse capacity is a concern with many slippy-api replicas, override via env.
