### PR TITLE
fix(slippy): best-effort aggregate writeback so step-write timeouts don't corrupt slip state

### DIFF
--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -46,6 +46,14 @@ const (
 	DefaultMaxOpenConns    = 50
 	DefaultMaxIdleConns    = 10
 	DefaultConnMaxLifetime = 60 * time.Second
+
+	// defaultMaxExecutionTime caps the server-side wall-clock budget (in seconds)
+	// for any individual query. This prevents a slow aggregate write-back or
+	// expensive read-modify-write from blocking goroutines indefinitely when the
+	// caller's context has already been cancelled (e.g. slippy-api's 15 s step
+	// timeout). ClickHouse will return an exception rather than hanging; callers
+	// that treat write-backs as best-effort can ignore the resulting error.
+	defaultMaxExecutionTime = 300
 )
 
 // ResolvePoolSettings returns the connection-pool values to use, substituting
@@ -400,6 +408,14 @@ func (chsession *ClickhouseSession) Connect(ch *ClickhouseConfig, ctx context.Co
 			ConnMaxLifetime: lifetime,
 			MaxOpenConns:    maxOpen,
 			MaxIdleConns:    maxIdle,
+			// Bound every query's server-side execution time. Prevents a slow
+			// aggregate write-back from keeping a server thread busy after the
+			// calling goroutine's context has timed out (e.g. slippy-api 15s
+			// step deadline). The value is intentionally generous (5 min) —
+			// it guards against runaway queries, not against fast timeouts.
+			Settings: clickhouse.Settings{
+				"max_execution_time": defaultMaxExecutionTime,
+			},
 		})
 		if err != nil {
 			return fmt.Errorf("error connecting to ClickHouse: %w", err)

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -587,11 +587,19 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	}
 
 	// Persist history and (where applicable) the aggregate status to routing_slips.
+	//
+	// The aggregate/cache write-back is BEST-EFFORT: insertComponentState above already
+	// durably recorded the step event in the conflict-free event-sourcing table. The
+	// routing_slips aggregate columns are a read-time cache — hydrateSlip recomputes
+	// every step/aggregate status from slip_component_states on every Load, so a
+	// lost or timed-out write-back self-heals on the next Load. Therefore any error
+	// from the write-back must NOT fail this call once the event insert has succeeded.
+	//
 	//   - componentName != "":  component step → aggregate write-back carries the history.
 	//   - IsAggregateStep:      aggregate step itself → aggregate write-back carries the history.
 	//   - otherwise:            pure pipeline step → call AppendHistory directly.
 	if componentName != "" || (s.pipelineConfig != nil && s.pipelineConfig.IsAggregateStep(stepName)) {
-		return s.updateAggregateStatusFromComponentStatesWithHistory(
+		if err := s.updateAggregateStatusFromComponentStatesWithHistory(
 			ctx,
 			correlationID,
 			stepName,
@@ -599,7 +607,19 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 			status,
 			insertedAt,
 			entry,
-		)
+		); err != nil {
+			// The event is durable; swallow the write-back error and let the next
+			// Load recompute aggregate status from slip_component_states.
+			s.logger.Warn(ctx,
+				"aggregate writeback failed after durable event insert; deferred to read-time hydration",
+				map[string]interface{}{
+					"correlation_id": correlationID,
+					"step":           stepName,
+					"component":      componentName,
+					"error":          err.Error(),
+				})
+		}
+		return nil
 	}
 
 	// Pure pipeline step: persist the history entry AND update the step-status column
@@ -609,11 +629,33 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	// unit_tests_status = "running" from hydrateSlip's first pass over slip_component_states).
 	// Passing the override makes the INSERT SELECT use the literal status we just wrote to
 	// slip_component_states, keeping routing_slips consistent without a Load+Update cycle.
+	//
+	// Same best-effort semantics: the event is already durable; swallow cache write-back
+	// errors so a timeout here does not corrupt slip state from the caller's perspective.
 	if s.pipelineConfig != nil {
 		colName := s.queryBuilder.StepStatusColumn(stepName)
-		return s.appendHistoryWithOverrides(ctx, correlationID, entry, stepStatusOverride{colName, status})
+		err := s.appendHistoryWithOverrides(ctx, correlationID, entry, stepStatusOverride{colName, status})
+		if err != nil {
+			s.logger.Warn(ctx,
+				"pipeline step history writeback failed after durable event insert; deferred to read-time hydration",
+				map[string]interface{}{
+					"correlation_id": correlationID,
+					"step":           stepName,
+					"error":          err.Error(),
+				})
+		}
+		return nil
 	}
-	return s.AppendHistory(ctx, correlationID, entry)
+	if err := s.AppendHistory(ctx, correlationID, entry); err != nil {
+		s.logger.Warn(ctx,
+			"history writeback failed after durable event insert; deferred to read-time hydration",
+			map[string]interface{}{
+				"correlation_id": correlationID,
+				"step":           stepName,
+				"error":          err.Error(),
+			})
+	}
+	return nil
 }
 
 // AppendHistory adds a state history entry to the slip.

--- a/slippy/clickhouse_store.go
+++ b/slippy/clickhouse_store.go
@@ -589,11 +589,16 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	// Persist history and (where applicable) the aggregate status to routing_slips.
 	//
 	// The aggregate/cache write-back is BEST-EFFORT: insertComponentState above already
-	// durably recorded the step event in the conflict-free event-sourcing table. The
-	// routing_slips aggregate columns are a read-time cache — hydrateSlip recomputes
-	// every step/aggregate status from slip_component_states on every Load, so a
-	// lost or timed-out write-back self-heals on the next Load. Therefore any error
-	// from the write-back must NOT fail this call once the event insert has succeeded.
+	// durably recorded the step event in the conflict-free event-sourcing table.
+	//
+	// Self-heal scope: hydrateSlip recomputes STEP and AGGREGATE STATUS from
+	// slip_component_states on every Load, so a lost write-back for those columns
+	// self-heals on the next Load. The state_history AUDIT ENTRY for this transition
+	// is NOT reconstructed by hydration — it lives only in the routing_slips
+	// state_history column written by this write-back, so a lost write-back permanently
+	// drops that audit entry. Therefore any error from the write-back must NOT fail
+	// this call once the event insert has succeeded, but callers should monitor the
+	// "state_history_lost" warning field to detect audit gaps.
 	//
 	//   - componentName != "":  component step → aggregate write-back carries the history.
 	//   - IsAggregateStep:      aggregate step itself → aggregate write-back carries the history.
@@ -608,16 +613,20 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 			insertedAt,
 			entry,
 		); err != nil {
-			// The event is durable; swallow the write-back error and let the next
-			// Load recompute aggregate status from slip_component_states.
-			s.logger.Warn(ctx,
-				"aggregate writeback failed after durable event insert; deferred to read-time hydration",
+			// The event is durable; swallow the write-back error. Step/aggregate STATUS
+			// self-heals on next Load (recomputed by hydrateSlip). The state_history
+			// audit entry for this transition is NOT rebuilt by hydration and is lost.
+			s.logger.Warn(
+				ctx,
+				"aggregate writeback failed after durable event insert; step/aggregate status will self-heal on next Load but state_history audit entry for this transition is lost",
 				map[string]interface{}{
-					"correlation_id": correlationID,
-					"step":           stepName,
-					"component":      componentName,
-					"error":          err.Error(),
-				})
+					"correlation_id":     correlationID,
+					"step":               stepName,
+					"component":          componentName,
+					"error":              err.Error(),
+					"state_history_lost": true,
+				},
+			)
 		}
 		return nil
 	}
@@ -630,30 +639,42 @@ func (s *ClickHouseStore) UpdateStepWithHistory(
 	// Passing the override makes the INSERT SELECT use the literal status we just wrote to
 	// slip_component_states, keeping routing_slips consistent without a Load+Update cycle.
 	//
-	// Same best-effort semantics: the event is already durable; swallow cache write-back
-	// errors so a timeout here does not corrupt slip state from the caller's perspective.
+	// Same best-effort semantics: the event is already durable; swallow write-back errors.
+	// Step STATUS self-heals on next Load (recomputed by hydrateSlip from slip_component_states).
+	// The state_history audit entry for this transition is NOT rebuilt by hydration and is lost
+	// if this write-back fails.
 	if s.pipelineConfig != nil {
 		colName := s.queryBuilder.StepStatusColumn(stepName)
 		err := s.appendHistoryWithOverrides(ctx, correlationID, entry, stepStatusOverride{colName, status})
 		if err != nil {
-			s.logger.Warn(ctx,
-				"pipeline step history writeback failed after durable event insert; deferred to read-time hydration",
+			s.logger.Warn(
+				ctx,
+				"pipeline step history writeback failed after durable event insert; step status will self-heal on next Load but state_history audit entry for this transition is lost",
 				map[string]interface{}{
-					"correlation_id": correlationID,
-					"step":           stepName,
-					"error":          err.Error(),
-				})
+					"correlation_id":     correlationID,
+					"step":               stepName,
+					"error":              err.Error(),
+					"state_history_lost": true,
+				},
+			)
 		}
 		return nil
 	}
+	// Fallback: no pipelineConfig, so call AppendHistory directly. Best-effort: the event
+	// is already durable. Step STATUS self-heals on next Load (recomputed by hydrateSlip).
+	// The state_history audit entry for this transition is NOT rebuilt by hydration and is
+	// lost if this write-back fails.
 	if err := s.AppendHistory(ctx, correlationID, entry); err != nil {
-		s.logger.Warn(ctx,
-			"history writeback failed after durable event insert; deferred to read-time hydration",
+		s.logger.Warn(
+			ctx,
+			"history writeback failed after durable event insert; step status will self-heal on next Load but state_history audit entry for this transition is lost",
 			map[string]interface{}{
-				"correlation_id": correlationID,
-				"step":           stepName,
-				"error":          err.Error(),
-			})
+				"correlation_id":     correlationID,
+				"step":               stepName,
+				"error":              err.Error(),
+				"state_history_lost": true,
+			},
+		)
 	}
 	return nil
 }

--- a/slippy/clickhouse_store_unit_test.go
+++ b/slippy/clickhouse_store_unit_test.go
@@ -6167,3 +6167,121 @@ func TestFilterActiveComponents_DirectUnit(t *testing.T) {
 		t.Errorf("expected all 2 active components kept, got %d", len(got))
 	}
 }
+
+// TestUpdateStepWithHistory_WritebackErrorAfterEventInsert verifies the best-effort
+// writeback semantics: when insertComponentState succeeds but the subsequent aggregate
+// writeback (or pipeline-step history writeback) returns an error, UpdateStepWithHistory
+// must return nil — not propagate the writeback error.
+//
+// The event record is the authoritative source of truth; routing_slips is a cache that
+// hydrateSlip recomputes from slip_component_states on every Load, so a failed writeback
+// self-heals on the next read.
+func TestUpdateStepWithHistory_WritebackErrorAfterEventInsert(t *testing.T) {
+	const corrID = "corr-best-effort-writeback"
+	writebackErr := fmt.Errorf("simulated CH timeout on aggregate writeback")
+
+	// -- Subtest 1: component step (aggregate writeback path) -----------------
+	t.Run("component_step_writeback_error_returns_nil", func(t *testing.T) {
+		// Base mock: event-log insert succeeds; routing_slips insert fails.
+		base := createMockSessionForUpdates(corrID, "myorg/myrepo", "main", "abc123", SlipStatusInProgress, 1)
+		origExec := base.ExecWithArgsFunc
+		base.ExecWithArgsFunc = func(ctx context.Context, stmt string, args ...any) error {
+			if strings.Contains(stmt, "routing_slips") && strings.Contains(stmt, "INSERT") {
+				return writebackErr
+			}
+			return origExec(ctx, stmt, args...)
+		}
+		store := NewClickHouseStoreFromSession(base, testPipelineConfig(), "ci")
+
+		entry := StateHistoryEntry{
+			Timestamp: time.Now(),
+			Step:      "builds",
+			Status:    StepStatusCompleted,
+			Actor:     "ci",
+		}
+
+		err := store.UpdateStepWithHistory(
+			context.Background(), corrID, "builds", "api", StepStatusCompleted, entry,
+		)
+		if err != nil {
+			t.Errorf("expected nil when writeback errors after durable event insert; got: %v", err)
+		}
+
+		// Confirm the event-log insert (slip_component_states) was still executed.
+		componentInserts := 0
+		for _, call := range base.ExecWithArgsCalls {
+			if strings.Contains(call.Stmt, TableSlipComponentStates) {
+				componentInserts++
+			}
+		}
+		if componentInserts != 1 {
+			t.Errorf("expected 1 slip_component_states insert, got %d", componentInserts)
+		}
+	})
+
+	// -- Subtest 2: insertComponentState failure must still propagate ----------
+	t.Run("event_insert_failure_propagates", func(t *testing.T) {
+		eventErr := fmt.Errorf("simulated CH failure on event insert")
+		base := createMockSessionForUpdates(corrID, "myorg/myrepo", "main", "abc123", SlipStatusInProgress, 1)
+		base.ExecWithArgsFunc = func(ctx context.Context, stmt string, args ...any) error {
+			if strings.Contains(stmt, TableSlipComponentStates) {
+				return eventErr
+			}
+			return nil
+		}
+		store := NewClickHouseStoreFromSession(base, testPipelineConfig(), "ci")
+
+		entry := StateHistoryEntry{
+			Timestamp: time.Now(),
+			Step:      "builds",
+			Status:    StepStatusCompleted,
+			Actor:     "ci",
+		}
+
+		err := store.UpdateStepWithHistory(
+			context.Background(), corrID, "builds", "api", StepStatusCompleted, entry,
+		)
+		if err == nil {
+			t.Error("expected error when event insert fails; got nil")
+		}
+	})
+
+	// -- Subtest 3: pure pipeline step writeback error returns nil -------------
+	t.Run("pure_pipeline_step_writeback_error_returns_nil", func(t *testing.T) {
+		base := createMockSessionForUpdates(corrID, "myorg/myrepo", "main", "abc123", SlipStatusInProgress, 1)
+		origExec := base.ExecWithArgsFunc
+		base.ExecWithArgsFunc = func(ctx context.Context, stmt string, args ...any) error {
+			if strings.Contains(stmt, "routing_slips") && strings.Contains(stmt, "INSERT") {
+				return writebackErr
+			}
+			return origExec(ctx, stmt, args...)
+		}
+		store := NewClickHouseStoreFromSession(base, testPipelineConfig(), "ci")
+
+		entry := StateHistoryEntry{
+			Timestamp: time.Now(),
+			Step:      "push_parsed",
+			Status:    StepStatusCompleted,
+			Actor:     "ci",
+		}
+
+		// "push_parsed" is a pure pipeline step (no component, not aggregate).
+		err := store.UpdateStepWithHistory(
+			context.Background(), corrID, "push_parsed", "", StepStatusCompleted, entry,
+		)
+		if err != nil {
+			t.Errorf("expected nil when pure-pipeline writeback errors after durable event insert; got: %v", err)
+		}
+
+		// Confirm the event-log insert still executed.
+		componentInserts := 0
+		for _, call := range base.ExecWithArgsCalls {
+			if strings.Contains(call.Stmt, TableSlipComponentStates) {
+				componentInserts++
+			}
+		}
+		if componentInserts != 1 {
+			t.Errorf("expected 1 slip_component_states insert, got %d", componentInserts)
+		}
+	})
+}


### PR DESCRIPTION
## What this fixes

Slippy CI step-writes were occasionally **corrupting slip state**. When a ClickHouse write ran long, the `routing_slips` aggregate-status writeback got cancelled and lost — leaving a step's status column frozen on `running` even though the step had actually finished. On 2026-06-22 this left 3 production slips stuck for hours, including one where a **failed** unit-tests step showed as `running` (the CI gate was blind to a real failure).

The key insight: the **event-log row is the source of truth**, and `routing_slips.<step>_status` is just a cache that `hydrateSlip` recomputes from the event log on every `Load`. So losing the cache writeback is harmless *for status* — it self-heals on the next read. The bug was that we treated the whole write as one all-or-nothing operation and let a slow cache writeback fail the call.

## The change

In `UpdateStepWithHistory`:
- The **event-log insert (`insertComponentState`) stays authoritative** — if it fails, the call still fails. Nothing changes there.
- The **aggregate / history writeback that runs after it is now best-effort** — on error or timeout it's logged and swallowed, and the call returns success. The status self-heals from the event log on the next `Load`, so the slip never freezes.

Plus a safety belt: set an explicit ClickHouse `max_execution_time` (300s) on the client, so once callers stop using a tiny hard timeout there's still a sane server-side ceiling rather than an unknown profile default.

## Honest caveat (called out in review)

Status self-heals; **`state_history` does not**. `hydrateSlip` rebuilds step/aggregate *status* from the event log but does not reconstruct the history blob, which is written only by the now-swallowed writeback. So a swallowed writeback permanently drops that transition's audit entry. That's an audit-trail gap, not a gating problem (gates read status, not history). The swallow log now carries a `state_history_lost` field so the gap is visible, and the code comments were corrected to stop over-claiming "self-heals on next Load."

## How it was validated

- `make lint` clean; `make test` green for `slippy` and `clickhouse`.
- New unit test asserts the core invariant: when the writeback errors but the event insert succeeded, `UpdateStepWithHistory` returns nil; when the event insert itself fails, the error still propagates.
- Reviewed by technical + security + adversarial passes (data-integrity focus). No fail-open: the gate reads the durable event log and holds closed on any non-success status.

## Merge order (multi-PR — this one is first)

1. **This PR (goLibMyCarrier)** — merge first so it cuts a beta tag.
2. **slippy-api** — bumps to the new goLib tag, raises its write timeout off 15s, makes its own writeback best-effort, and keeps returning a retryable status (not a false "accepted") so the CLI re-drives a genuinely-lost write.
3. **Slippy CLI** — reconcile-on-timeout (component-aware) so a slow-but-successful write no longer hard-fails the Argo job. Independent of the goLib tag; can land any time after.

Ref: ADO #82917.
